### PR TITLE
Add Tracking page: Nostr GPS publisher and navbar entry

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { Routes, Route } from 'react-router-dom';
 import { Analytics } from '@vercel/analytics/react';
 import MainApp  from './MainApp';
@@ -22,6 +22,7 @@ import Posts from './pages/Posts';
 import Everpeace from './pages/Everpeace';
 import { Trackathons } from './pages/Trackathons';
 import { TrackathonDetail } from './pages/TrackathonDetail';
+import { Tracking } from './pages/Tracking';
 
 import { NotificationProvider } from './context/NotificationContext';
 import { StatsProvider } from './context/StatsContext';
@@ -37,6 +38,7 @@ function App() {
             <Layout>
               <Routes>
                 <Route path="/" element={<MainApp />} />
+                <Route path="/tracking" element={<Tracking />} />
                 <Route path="/trails" element={<Trails />} />
                 <Route path="/events" element={<Events />} />
                 <Route path="/track/:trackId" element={<TrackPage />} />

--- a/src/components/DropdownMenu.tsx
+++ b/src/components/DropdownMenu.tsx
@@ -34,13 +34,6 @@ export const DropdownMenu = ({ isAuthed, onAuth }: DropdownMenuProps) => {
         <div className="nav-dropdown-menu">
           <ul>
             <li onClick={() => {
-              navigate('/tracking');
-              setIsOpen(false);
-            }}>
-              <span className="material-icons">my_location</span>
-              Tracking
-            </li>
-            <li onClick={() => {
               navigate('/trackathons');
               setIsOpen(false);
             }}>

--- a/src/components/DropdownMenu.tsx
+++ b/src/components/DropdownMenu.tsx
@@ -34,6 +34,13 @@ export const DropdownMenu = ({ isAuthed, onAuth }: DropdownMenuProps) => {
         <div className="nav-dropdown-menu">
           <ul>
             <li onClick={() => {
+              navigate('/tracking');
+              setIsOpen(false);
+            }}>
+              <span className="material-icons">my_location</span>
+              Tracking
+            </li>
+            <li onClick={() => {
               navigate('/trackathons');
               setIsOpen(false);
             }}>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React from 'react';
 import {  useNavigate } from 'react-router-dom';
 
 import '../styles/Navbar.css';
@@ -16,7 +16,7 @@ export const Navbar = () => {
     state: { isAuthed, principal },
   } = useGlobalContext();
   const logout = useLogout();
-  const [loginModal, setLoginModal] = useSetLoginModal();
+  const [, setLoginModal] = useSetLoginModal();
 
   const handleLogout = async () => {
     // Get AuthClient and logout
@@ -47,6 +47,7 @@ export const Navbar = () => {
 
           {/* Desktop menu items */}
           <div className="desktop-menu">
+            <Link to="/tracking" className="nav-link"><span className="material-icons">my_location</span>Tracking</Link>
             <Link to="/trackathons" className="nav-link"><span className="material-icons">flag</span>Trackathons</Link>
             {/* <Link to="/everpeace" className="nav-link"><span className="material-icons">terrain</span>Everpeace</Link> */}
             {/* <Link to="https://icevent.app" className="nav-link"><span className="material-icons">event</span>Events</Link> */}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -47,7 +47,6 @@ export const Navbar = () => {
 
           {/* Desktop menu items */}
           <div className="desktop-menu">
-            <Link to="/tracking" className="nav-link"><span className="material-icons">my_location</span>Tracking</Link>
             <Link to="/trackathons" className="nav-link"><span className="material-icons">flag</span>Trackathons</Link>
             {/* <Link to="/everpeace" className="nav-link"><span className="material-icons">terrain</span>Everpeace</Link> */}
             {/* <Link to="https://icevent.app" className="nav-link"><span className="material-icons">event</span>Events</Link> */}

--- a/src/pages/Profile.tsx
+++ b/src/pages/Profile.tsx
@@ -3,16 +3,15 @@ import { Navigate } from 'react-router-dom';
 
 import '../styles/Profile.css';
 
-import { Tracks } from '../components/Tracks';
 import { Trails } from '../components/Trails';
 import { GroupManagement } from '../components/GroupManagement';
 
 import { Settings } from '../components/Settings';
-import { useNotification } from '../context/NotificationContext';
 import { TrackAchievements } from '../components/TrackAchievements';
 import { ArStorage } from '../components/ArStorage';
 import { SavedPoints } from '../components/SavedPoints';
 import { Wallet } from '../components/Wallet';
+import { Tracking } from './Tracking';
 
 import { UserStats } from '../types/UserStats';
 import { useGlobalContext, useAlltracks } from '../components/Store';
@@ -23,7 +22,6 @@ export const Profile: React.FC = () => {
   const [activeTab, setActiveTab] = useState('profile');
   const { state: { isAuthed, principal } } = useGlobalContext();
 
-  const { showNotification } = useNotification();
   const [userStats, setUserStats] = useState<UserStats>({
     totalDistance: 0,
     totalHours: 0,
@@ -33,6 +31,8 @@ export const Profile: React.FC = () => {
   });
 
   useEffect(() => {
+    if (!isAuthed || !principal) return;
+
     console.log("Loading user stats...")
     const loadUserStats = async () => {
       console.log("Loading user stats in...")
@@ -52,7 +52,7 @@ export const Profile: React.FC = () => {
 
     }
     loadUserStats();
-  }, [isAuthed]);
+  }, [alltracks, isAuthed, principal]);
 
 
   if (!isAuthed) {
@@ -71,6 +71,14 @@ export const Profile: React.FC = () => {
             >
               <span className="material-icons">person</span>
               Prove of Tracking
+            </div>
+
+            <div
+              className={`sidebar-item ${activeTab === 'tracking' ? 'active' : ''}`}
+              onClick={() => setActiveTab('tracking')}
+            >
+              <span className="material-icons">my_location</span>
+              Tracking
             </div>
 
 
@@ -141,6 +149,10 @@ export const Profile: React.FC = () => {
                   <TrackAchievements stats={userStats} userId={principal.toText()} />
                 </div>
               </>
+            )}
+
+            {activeTab === 'tracking' && (
+              <Tracking />
             )}
 
 

--- a/src/pages/Tracking.css
+++ b/src/pages/Tracking.css
@@ -1,0 +1,248 @@
+.tracking-page {
+  max-width: 960px;
+  margin: 0 auto 48px;
+  padding: 0 20px;
+  color: #173b2a;
+}
+
+.tracking-hero,
+.tracking-card {
+  background: #ffffff;
+  border: 1px solid #dceee4;
+  border-radius: 18px;
+  box-shadow: 0 12px 30px rgba(8, 126, 65, 0.08);
+}
+
+.tracking-hero {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 28px;
+  margin-bottom: 18px;
+}
+
+.tracking-hero h1 {
+  margin: 0 0 8px;
+  font-size: clamp(2rem, 5vw, 3.5rem);
+  color: #07623e;
+}
+
+.tracking-hero p {
+  margin: 0;
+  max-width: 640px;
+  color: #4c6659;
+  line-height: 1.6;
+}
+
+.tracking-eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.12em;
+  font-size: 0.78rem;
+  font-weight: 800;
+  color: #119515 !important;
+  margin-bottom: 8px !important;
+}
+
+.tracking-alert,
+.tracking-pubkey {
+  border-radius: 12px;
+  margin-bottom: 18px;
+  padding: 14px 16px;
+}
+
+.tracking-alert {
+  background: #fff7e6;
+  border: 1px solid #ffd88a;
+  color: #755200;
+}
+
+.tracking-pubkey {
+  overflow-wrap: anywhere;
+  background: #effaf3;
+  border: 1px solid #bfe8cb;
+  color: #07623e;
+  font-family: monospace;
+}
+
+.tracking-card {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 24px;
+  margin-bottom: 18px;
+}
+
+.tracking-card h2 {
+  margin: 0;
+  color: #07623e;
+}
+
+.tracking-card label {
+  font-weight: 800;
+  color: #173b2a;
+}
+
+.tracking-card input,
+.tracking-card textarea {
+  width: 100%;
+  border: 1px solid #bddac7;
+  border-radius: 10px;
+  padding: 12px;
+  color: #173b2a;
+  font: inherit;
+  background: #fbfffc;
+  box-sizing: border-box;
+}
+
+.tracking-card textarea {
+  resize: vertical;
+}
+
+.tracking-card small,
+.tracking-accuracy {
+  color: #607568;
+  line-height: 1.4;
+}
+
+.tracking-grid,
+.tracking-location-row {
+  display: grid;
+  gap: 16px;
+}
+
+.tracking-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.tracking-grid > div,
+.tracking-location-row > div {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.tracking-location-row {
+  grid-template-columns: 1fr 1fr auto;
+  align-items: end;
+}
+
+.tracking-preview {
+  display: flex;
+  justify-content: center;
+  padding: 14px;
+  background: #f4fbf6;
+  border: 1px dashed #a9d8b7;
+  border-radius: 14px;
+}
+
+.tracking-preview img {
+  max-width: 100%;
+  max-height: 320px;
+  object-fit: contain;
+  border-radius: 12px;
+}
+
+.tracking-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: 8px;
+}
+
+.tracking-primary-button,
+.tracking-secondary-button {
+  border: none;
+  border-radius: 999px;
+  cursor: pointer;
+  font-weight: 800;
+  padding: 12px 18px;
+  transition: transform 0.2s ease, opacity 0.2s ease;
+  white-space: nowrap;
+}
+
+.tracking-primary-button:hover,
+.tracking-secondary-button:hover {
+  transform: translateY(-1px);
+}
+
+.tracking-primary-button:disabled,
+.tracking-secondary-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
+  transform: none;
+}
+
+.tracking-primary-button {
+  background: #119515;
+  color: #ffffff;
+}
+
+.tracking-secondary-button {
+  background: #e8f7ee;
+  color: #07623e;
+}
+
+.tracking-results {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.tracking-results li {
+  display: grid;
+  grid-template-columns: 100px 1fr;
+  gap: 4px 12px;
+  border-radius: 12px;
+  padding: 12px;
+}
+
+.tracking-results small {
+  grid-column: 2;
+}
+
+.tracking-result-ok {
+  background: #eefaf2;
+  border: 1px solid #bfe8cb;
+}
+
+.tracking-result-error {
+  background: #fff0f0;
+  border: 1px solid #ffc3c3;
+}
+
+.tracking-result-ok strong {
+  color: #087e41;
+}
+
+.tracking-result-error strong {
+  color: #b42318;
+}
+
+@media (max-width: 760px) {
+  .tracking-hero,
+  .tracking-location-row,
+  .tracking-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .tracking-hero {
+    display: grid;
+    padding: 22px;
+  }
+
+  .tracking-secondary-button,
+  .tracking-primary-button {
+    width: 100%;
+  }
+
+  .tracking-results li {
+    grid-template-columns: 1fr;
+  }
+
+  .tracking-results small {
+    grid-column: 1;
+  }
+}

--- a/src/pages/Tracking.css
+++ b/src/pages/Tracking.css
@@ -1,12 +1,14 @@
 .tracking-page {
-  max-width: 960px;
+  max-width: 1040px;
   margin: 0 auto 48px;
   padding: 0 20px;
   color: #173b2a;
 }
 
 .tracking-hero,
-.tracking-card {
+.tracking-card,
+.tracking-post-card,
+.tracking-feed-section {
   background: #ffffff;
   border: 1px solid #dceee4;
   border-radius: 18px;
@@ -30,9 +32,21 @@
 
 .tracking-hero p {
   margin: 0;
-  max-width: 640px;
+  max-width: 680px;
   color: #4c6659;
   line-height: 1.6;
+}
+
+.tracking-hero-actions,
+.tracking-actions {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+.tracking-hero-actions {
+  flex-wrap: wrap;
 }
 
 .tracking-eyebrow {
@@ -41,7 +55,7 @@
   font-size: 0.78rem;
   font-weight: 800;
   color: #119515 !important;
-  margin-bottom: 8px !important;
+  margin: 0 0 8px !important;
 }
 
 .tracking-alert,
@@ -73,7 +87,18 @@
   margin-bottom: 18px;
 }
 
-.tracking-card h2 {
+.tracking-form-card {
+  box-shadow: none;
+  margin-bottom: 0;
+}
+
+.tracking-results-card {
+  margin-bottom: 18px;
+}
+
+.tracking-card h2,
+.tracking-feed-header h2,
+.tracking-modal-header h2 {
   margin: 0;
   color: #07623e;
 }
@@ -144,24 +169,28 @@
 }
 
 .tracking-actions {
-  display: flex;
-  justify-content: flex-end;
   margin-top: 8px;
 }
 
 .tracking-primary-button,
-.tracking-secondary-button {
+.tracking-secondary-button,
+.tracking-close-button {
   border: none;
-  border-radius: 999px;
   cursor: pointer;
   font-weight: 800;
-  padding: 12px 18px;
   transition: transform 0.2s ease, opacity 0.2s ease;
+}
+
+.tracking-primary-button,
+.tracking-secondary-button {
+  border-radius: 999px;
+  padding: 12px 18px;
   white-space: nowrap;
 }
 
 .tracking-primary-button:hover,
-.tracking-secondary-button:hover {
+.tracking-secondary-button:hover,
+.tracking-close-button:hover {
   transform: translateY(-1px);
 }
 
@@ -180,6 +209,131 @@
 .tracking-secondary-button {
   background: #e8f7ee;
   color: #07623e;
+}
+
+.tracking-close-button {
+  display: grid;
+  place-items: center;
+  min-width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  background: #e8f7ee;
+  color: #07623e;
+  font-size: 1.6rem;
+  line-height: 1;
+}
+
+.tracking-feed-section {
+  padding: 24px;
+}
+
+.tracking-feed-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.tracking-feed-header span,
+.tracking-post-relays {
+  color: #607568;
+  font-size: 0.9rem;
+}
+
+.tracking-feed-list {
+  display: grid;
+  gap: 16px;
+}
+
+.tracking-empty-state {
+  border: 1px dashed #a9d8b7;
+  border-radius: 14px;
+  background: #f4fbf6;
+  color: #4c6659;
+  padding: 24px;
+  text-align: center;
+}
+
+.tracking-post-card {
+  display: grid;
+  gap: 12px;
+  padding: 18px;
+}
+
+.tracking-post-meta,
+.tracking-post-location {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.tracking-post-meta {
+  color: #607568;
+  font-size: 0.88rem;
+  flex-wrap: wrap;
+}
+
+.tracking-post-content {
+  margin: 0;
+  white-space: pre-wrap;
+  line-height: 1.55;
+  overflow-wrap: anywhere;
+}
+
+.tracking-post-image {
+  width: 100%;
+  max-height: 420px;
+  object-fit: cover;
+  border-radius: 14px;
+  background: #f4fbf6;
+}
+
+.tracking-post-location {
+  align-items: center;
+  border-radius: 12px;
+  background: #effaf3;
+  color: #07623e;
+  padding: 10px 12px;
+  flex-wrap: wrap;
+}
+
+.tracking-post-location a {
+  color: #087e41;
+  font-weight: 800;
+  text-decoration: none;
+}
+
+.tracking-post-relays {
+  overflow-wrap: anywhere;
+}
+
+.tracking-modal-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 20000;
+  display: flex;
+  justify-content: center;
+  align-items: flex-start;
+  overflow-y: auto;
+  background: rgba(8, 34, 21, 0.58);
+  padding: 32px 18px;
+}
+
+.tracking-modal {
+  width: min(920px, 100%);
+  background: #ffffff;
+  border-radius: 22px;
+  box-shadow: 0 28px 80px rgba(0, 0, 0, 0.25);
+  padding: 22px;
+}
+
+.tracking-modal-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
 }
 
 .tracking-results {
@@ -223,19 +377,40 @@
 
 @media (max-width: 760px) {
   .tracking-hero,
+  .tracking-feed-header,
+  .tracking-post-meta,
+  .tracking-post-location,
+  .tracking-modal-header {
+    display: grid;
+  }
+
   .tracking-location-row,
   .tracking-grid {
     grid-template-columns: 1fr;
   }
 
-  .tracking-hero {
-    display: grid;
+  .tracking-hero,
+  .tracking-feed-section,
+  .tracking-card {
     padding: 22px;
+  }
+
+  .tracking-hero-actions,
+  .tracking-actions {
+    justify-content: stretch;
   }
 
   .tracking-secondary-button,
   .tracking-primary-button {
     width: 100%;
+  }
+
+  .tracking-modal-overlay {
+    padding: 12px;
+  }
+
+  .tracking-modal {
+    padding: 16px;
   }
 
   .tracking-results li {

--- a/src/pages/Tracking.tsx
+++ b/src/pages/Tracking.tsx
@@ -1,4 +1,4 @@
-import React, { useMemo, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import './Tracking.css';
 import { useNotification } from '../context/NotificationContext';
 
@@ -23,6 +23,18 @@ type PublishResult = {
   message: string;
 };
 
+type TrackingPost = {
+  id: string;
+  pubkey: string;
+  content: string;
+  createdAt: number;
+  image?: string;
+  latitude?: string;
+  longitude?: string;
+  mapUrl?: string;
+  relays: string[];
+};
+
 declare global {
   interface Window {
     nostr?: NostrProvider;
@@ -38,6 +50,7 @@ const DEFAULT_RELAYS = [
 ];
 
 const GEOHASH_BASE32 = '0123456789bcdefghjkmnpqrstuvwxyz';
+const FEED_LIMIT = 50;
 
 const toHex = (buffer: ArrayBuffer) => Array.from(new Uint8Array(buffer))
   .map((byte) => byte.toString(16).padStart(2, '0'))
@@ -103,6 +116,90 @@ const normalizeRelays = (relayText: string) => relayText
   .filter(Boolean)
   .filter((relay, index, relays) => relays.indexOf(relay) === index);
 
+const isNostrEvent = (value: unknown): value is NostrEvent => {
+  if (!value || typeof value !== 'object') return false;
+  const event = value as Partial<NostrEvent>;
+  return typeof event.pubkey === 'string'
+    && typeof event.created_at === 'number'
+    && typeof event.kind === 'number'
+    && Array.isArray(event.tags)
+    && typeof event.content === 'string';
+};
+
+const getTagValues = (event: NostrEvent, tagName: string) => event.tags
+  .filter((tag) => tag[0] === tagName)
+  .map((tag) => tag.slice(1));
+
+const getFirstTagValue = (event: NostrEvent, tagName: string) => getTagValues(event, tagName)[0]?.[0];
+
+const isAllTracksEvent = (event: NostrEvent) => {
+  const topicTags = getTagValues(event, 't').flat().map((tag) => tag.toLowerCase());
+  const client = getFirstTagValue(event, 'client')?.toLowerCase();
+  return event.kind === 1 && topicTags.includes('alltracks') && (topicTags.includes('tracking') || client === 'alltracks');
+};
+
+const getPostImage = (event: NostrEvent) => {
+  const imetaUrl = getTagValues(event, 'imeta')
+    .flat()
+    .find((value) => value.startsWith('url '))
+    ?.replace(/^url\s+/, '');
+  if (imetaUrl) return imetaUrl;
+
+  const referenceUrl = getTagValues(event, 'r')
+    .flat()
+    .find((value) => /^https?:\/\/.+\.(png|jpe?g|gif|webp|avif)(\?.*)?$/i.test(value) || value.startsWith('data:image/'));
+  return referenceUrl;
+};
+
+const getPostLocation = (event: NostrEvent) => {
+  const location = getTagValues(event, 'location')[0];
+  if (location?.[0] && location?.[1]) {
+    return { latitude: location[0], longitude: location[1] };
+  }
+
+  const match = event.content.match(/📍\s*(-?\d+(?:\.\d+)?),\s*(-?\d+(?:\.\d+)?)/);
+  if (match) {
+    return { latitude: match[1], longitude: match[2] };
+  }
+
+  return {};
+};
+
+const getPostMapUrl = (event: NostrEvent) => getTagValues(event, 'r')
+  .flat()
+  .find((value) => value.includes('openstreetmap.org'));
+
+const toTrackingPost = (event: NostrEvent, relay: string): TrackingPost => ({
+  id: event.id || `${event.pubkey}-${event.created_at}`,
+  pubkey: event.pubkey,
+  content: event.content,
+  createdAt: event.created_at,
+  image: getPostImage(event),
+  ...getPostLocation(event),
+  mapUrl: getPostMapUrl(event),
+  relays: [relay],
+});
+
+const mergePosts = (posts: TrackingPost[]) => {
+  const postMap = new Map<string, TrackingPost>();
+
+  posts.forEach((post) => {
+    const existing = postMap.get(post.id);
+    if (existing) {
+      postMap.set(post.id, {
+        ...existing,
+        relays: [...new Set([...existing.relays, ...post.relays])],
+      });
+    } else {
+      postMap.set(post.id, post);
+    }
+  });
+
+  return Array.from(postMap.values())
+    .sort((a, b) => b.createdAt - a.createdAt)
+    .slice(0, FEED_LIMIT);
+};
+
 const publishToRelay = (relay: string, event: NostrEvent): Promise<PublishResult> => new Promise((resolve) => {
   let settled = false;
   const socket = new WebSocket(relay);
@@ -127,14 +224,65 @@ const publishToRelay = (relay: string, event: NostrEvent): Promise<PublishResult
   socket.onmessage = (message) => {
     try {
       const payload = JSON.parse(message.data);
-      if (payload[0] === 'OK' && payload[1] === event.id) {
-        settle(Boolean(payload[2]), payload[3] || (payload[2] ? 'Accepted.' : 'Rejected.'));
+      if (Array.isArray(payload) && payload[0] === 'OK' && payload[1] === event.id) {
+        settle(Boolean(payload[2]), String(payload[3] || (payload[2] ? 'Accepted.' : 'Rejected.')));
       }
-      if (payload[0] === 'NOTICE') {
-        settle(false, payload[1] || 'Relay returned a notice.');
+      if (Array.isArray(payload) && payload[0] === 'NOTICE') {
+        settle(false, String(payload[1] || 'Relay returned a notice.'));
       }
     } catch {
       settle(false, 'Relay returned an invalid response.');
+    }
+  };
+});
+
+const fetchPostsFromRelay = (relay: string): Promise<TrackingPost[]> => new Promise((resolve) => {
+  const socket = new WebSocket(relay);
+  const subscriptionId = `alltracks-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+  const posts: TrackingPost[] = [];
+  let settled = false;
+
+  const settle = () => {
+    if (settled) return;
+    settled = true;
+    window.clearTimeout(timeout);
+    try {
+      socket.send(JSON.stringify(['CLOSE', subscriptionId]));
+    } catch {
+      // Socket may already be closed by the relay.
+    }
+    socket.close();
+    resolve(posts);
+  };
+
+  const timeout = window.setTimeout(settle, 4500);
+
+  socket.onopen = () => {
+    socket.send(JSON.stringify([
+      'REQ',
+      subscriptionId,
+      {
+        kinds: [1],
+        '#t': ['alltracks'],
+        limit: FEED_LIMIT,
+      },
+    ]));
+  };
+  socket.onerror = settle;
+  socket.onmessage = (message) => {
+    try {
+      const payload = JSON.parse(message.data);
+      if (!Array.isArray(payload)) return;
+
+      if (payload[0] === 'EVENT' && payload[1] === subscriptionId && isNostrEvent(payload[2]) && isAllTracksEvent(payload[2])) {
+        posts.push(toTrackingPost(payload[2], relay));
+      }
+
+      if (payload[0] === 'EOSE' && payload[1] === subscriptionId) {
+        settle();
+      }
+    } catch {
+      // Ignore malformed relay messages and continue collecting from this relay.
     }
   };
 });
@@ -151,11 +299,41 @@ export const Tracking = () => {
   const [pubkey, setPubkey] = useState('');
   const [isLocating, setIsLocating] = useState(false);
   const [isPublishing, setIsPublishing] = useState(false);
+  const [isPostModalOpen, setIsPostModalOpen] = useState(false);
+  const [isFeedLoading, setIsFeedLoading] = useState(false);
+  const [feedPosts, setFeedPosts] = useState<TrackingPost[]>([]);
   const [results, setResults] = useState<PublishResult[]>([]);
 
   const relays = useMemo(() => normalizeRelays(relayText), [relayText]);
   const hasNostrExtension = typeof window !== 'undefined' && Boolean(window.nostr);
   const selectedImage = photoPreview || photoUrl;
+
+  const fetchLatestPosts = async () => {
+    if (relays.length === 0) {
+      showNotification('Add at least one public relay to load the feed.', 'error');
+      return;
+    }
+
+    setIsFeedLoading(true);
+    try {
+      const relayPosts = await Promise.all(relays.map((relay) => fetchPostsFromRelay(relay)));
+      const latestPosts = mergePosts(relayPosts.flat());
+      setFeedPosts(latestPosts);
+      if (latestPosts.length === 0) {
+        showNotification('No AllTracks tracking posts found on the configured relays.', 'info');
+      }
+    } catch {
+      showNotification('Unable to load the latest tracking posts.', 'error');
+    } finally {
+      setIsFeedLoading(false);
+    }
+  };
+
+  useEffect(() => {
+    fetchLatestPosts();
+    // Run once on first load with the default public relays.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const connectNostr = async () => {
     if (!window.nostr) {
@@ -266,6 +444,15 @@ export const Tracking = () => {
     return { ...signedEvent, id: signedEvent.id || unsignedEvent.id };
   };
 
+  const resetPostForm = () => {
+    setContent('');
+    setPhotoUrl('');
+    setPhotoPreview('');
+    setLatitude('');
+    setLongitude('');
+    setAccuracy(null);
+  };
+
   const publishTrackingPost = async () => {
     if (relays.length === 0) {
       showNotification('Add at least one public relay.', 'error');
@@ -278,10 +465,15 @@ export const Tracking = () => {
       const event = await buildEvent();
       const publishResults = await Promise.all(relays.map((relay) => publishToRelay(relay, event)));
       setResults(publishResults);
-      const accepted = publishResults.filter((result) => result.ok).length;
-      if (accepted > 0) {
-        showNotification(`Tracking post published to ${accepted}/${publishResults.length} relays.`, 'success');
-        setContent('');
+      const acceptedResults = publishResults.filter((result) => result.ok);
+      if (acceptedResults.length > 0) {
+        showNotification(`Tracking post published to ${acceptedResults.length}/${publishResults.length} relays.`, 'success');
+        setFeedPosts((existingPosts) => mergePosts([
+          { ...toTrackingPost(event, acceptedResults[0].relay), relays: acceptedResults.map((result) => result.relay) },
+          ...existingPosts,
+        ]));
+        resetPostForm();
+        setIsPostModalOpen(false);
       } else {
         showNotification('No relays accepted the tracking post.', 'error');
       }
@@ -300,104 +492,22 @@ export const Tracking = () => {
           <p className="tracking-eyebrow">Nostr GPS publishing</p>
           <h1>Tracking</h1>
           <p>
-            Share an AllTracks update with content, a photo reference, and GPS coordinates to multiple public Nostr relays.
+            Read the latest AllTracks tracking posts and share your own photo, content, and GPS location through public Nostr relays.
           </p>
         </div>
-        <button className="tracking-secondary-button" onClick={connectNostr} disabled={!hasNostrExtension}>
-          {pubkey ? 'Signer Connected' : 'Connect Nostr Signer'}
-        </button>
-      </section>
-
-      {!hasNostrExtension && (
-        <div className="tracking-alert">
-          A Nostr browser signer such as Alby, nos2x, or another NIP-07 extension is required to sign and publish events.
-        </div>
-      )}
-
-      {pubkey && <div className="tracking-pubkey">Public key: {pubkey}</div>}
-
-      <section className="tracking-card">
-        <label htmlFor="tracking-content">Content</label>
-        <textarea
-          id="tracking-content"
-          value={content}
-          onChange={(event) => setContent(event.target.value)}
-          rows={5}
-          placeholder="What are you seeing on your track?"
-        />
-
-        <div className="tracking-grid">
-          <div>
-            <label htmlFor="tracking-photo-url">Photo URL</label>
-            <input
-              id="tracking-photo-url"
-              type="url"
-              value={photoUrl}
-              onChange={(event) => {
-                setPhotoUrl(event.target.value);
-                setPhotoPreview('');
-              }}
-              placeholder="https://example.com/photo.jpg"
-            />
-            <small>Public relays store Nostr events, not media files. A hosted image URL is recommended.</small>
-          </div>
-          <div>
-            <label htmlFor="tracking-photo-file">Or attach a small photo as a data URI</label>
-            <input id="tracking-photo-file" type="file" accept="image/*" onChange={handlePhotoFile} />
-            <small>Use small images only; many relays reject large events.</small>
-          </div>
-        </div>
-
-        {selectedImage && (
-          <div className="tracking-preview">
-            <img src={selectedImage} alt="Selected tracking attachment preview" />
-          </div>
-        )}
-
-        <div className="tracking-location-row">
-          <div>
-            <label htmlFor="tracking-latitude">Latitude</label>
-            <input
-              id="tracking-latitude"
-              value={latitude}
-              onChange={(event) => setLatitude(event.target.value)}
-              placeholder="49.282700"
-            />
-          </div>
-          <div>
-            <label htmlFor="tracking-longitude">Longitude</label>
-            <input
-              id="tracking-longitude"
-              value={longitude}
-              onChange={(event) => setLongitude(event.target.value)}
-              placeholder="-123.120700"
-            />
-          </div>
-          <button className="tracking-secondary-button" onClick={getCurrentLocation} disabled={isLocating}>
-            {isLocating ? 'Getting GPS…' : 'Use Current GPS'}
+        <div className="tracking-hero-actions">
+          <button className="tracking-secondary-button" onClick={fetchLatestPosts} disabled={isFeedLoading}>
+            {isFeedLoading ? 'Refreshing…' : 'Refresh Feed'}
           </button>
-        </div>
-        {accuracy !== null && <p className="tracking-accuracy">GPS accuracy: about {Math.round(accuracy)} meters.</p>}
-
-        <label htmlFor="tracking-relays">Public relays</label>
-        <textarea
-          id="tracking-relays"
-          value={relayText}
-          onChange={(event) => setRelayText(event.target.value)}
-          rows={5}
-        />
-        <small>Separate relay URLs with commas, spaces, or new lines. Publishing will fan out to every relay listed.</small>
-
-        <div className="tracking-actions">
-          <button className="tracking-primary-button" onClick={publishTrackingPost} disabled={isPublishing || !pubkey}>
-            {isPublishing ? 'Publishing…' : `Publish to ${relays.length} Relay${relays.length === 1 ? '' : 's'}`}
+          <button className="tracking-primary-button" onClick={() => setIsPostModalOpen(true)}>
+            Open Post Form
           </button>
         </div>
       </section>
 
       {results.length > 0 && (
-        <section className="tracking-card">
-          <h2>Relay results</h2>
+        <section className="tracking-card tracking-results-card">
+          <h2>Last publish results</h2>
           <ul className="tracking-results">
             {results.map((result) => (
               <li key={result.relay} className={result.ok ? 'tracking-result-ok' : 'tracking-result-error'}>
@@ -408,6 +518,164 @@ export const Tracking = () => {
             ))}
           </ul>
         </section>
+      )}
+
+      <section className="tracking-feed-section">
+        <div className="tracking-feed-header">
+          <div>
+            <p className="tracking-eyebrow">Platform feed</p>
+            <h2>Latest posts</h2>
+          </div>
+          <span>{feedPosts.length} post{feedPosts.length === 1 ? '' : 's'}</span>
+        </div>
+
+        {isFeedLoading && <div className="tracking-empty-state">Loading latest AllTracks posts from public relays…</div>}
+
+        {!isFeedLoading && feedPosts.length === 0 && (
+          <div className="tracking-empty-state">
+            No AllTracks tracking posts were found yet. Open the post form to publish the first update.
+          </div>
+        )}
+
+        <div className="tracking-feed-list">
+          {feedPosts.map((post) => (
+            <article className="tracking-post-card" key={post.id}>
+              <div className="tracking-post-meta">
+                <span>{new Date(post.createdAt * 1000).toLocaleString()}</span>
+                <span title={post.pubkey}>npub…{post.pubkey.slice(-10)}</span>
+              </div>
+              <p className="tracking-post-content">{post.content}</p>
+              {post.image && (
+                <img className="tracking-post-image" src={post.image} alt="Tracking post attachment" loading="lazy" />
+              )}
+              {(post.latitude && post.longitude) && (
+                <div className="tracking-post-location">
+                  <span>📍 {post.latitude}, {post.longitude}</span>
+                  {post.mapUrl && <a href={post.mapUrl} target="_blank" rel="noreferrer">Open map</a>}
+                </div>
+              )}
+              <div className="tracking-post-relays">
+                Seen on {post.relays.length} relay{post.relays.length === 1 ? '' : 's'}: {post.relays.join(', ')}
+              </div>
+            </article>
+          ))}
+        </div>
+      </section>
+
+      {isPostModalOpen && (
+        <div className="tracking-modal-overlay" role="presentation" onClick={() => setIsPostModalOpen(false)}>
+          <section
+            className="tracking-modal"
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="tracking-modal-title"
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="tracking-modal-header">
+              <div>
+                <p className="tracking-eyebrow">Create tracking post</p>
+                <h2 id="tracking-modal-title">Post to Nostr</h2>
+              </div>
+              <button className="tracking-close-button" onClick={() => setIsPostModalOpen(false)} aria-label="Close tracking post form">
+                ×
+              </button>
+            </div>
+
+            {!hasNostrExtension && (
+              <div className="tracking-alert">
+                A Nostr browser signer such as Alby, nos2x, or another NIP-07 extension is required to sign and publish events.
+              </div>
+            )}
+
+            {pubkey && <div className="tracking-pubkey">Public key: {pubkey}</div>}
+
+            <div className="tracking-card tracking-form-card">
+              <button className="tracking-secondary-button" onClick={connectNostr} disabled={!hasNostrExtension}>
+                {pubkey ? 'Signer Connected' : 'Connect Nostr Signer'}
+              </button>
+
+              <label htmlFor="tracking-content">Content</label>
+              <textarea
+                id="tracking-content"
+                value={content}
+                onChange={(event) => setContent(event.target.value)}
+                rows={5}
+                placeholder="What are you seeing on your track?"
+              />
+
+              <div className="tracking-grid">
+                <div>
+                  <label htmlFor="tracking-photo-url">Photo URL</label>
+                  <input
+                    id="tracking-photo-url"
+                    type="url"
+                    value={photoUrl}
+                    onChange={(event) => {
+                      setPhotoUrl(event.target.value);
+                      setPhotoPreview('');
+                    }}
+                    placeholder="https://example.com/photo.jpg"
+                  />
+                  <small>Public relays store Nostr events, not media files. A hosted image URL is recommended.</small>
+                </div>
+                <div>
+                  <label htmlFor="tracking-photo-file">Or attach a small photo as a data URI</label>
+                  <input id="tracking-photo-file" type="file" accept="image/*" onChange={handlePhotoFile} />
+                  <small>Use small images only; many relays reject large events.</small>
+                </div>
+              </div>
+
+              {selectedImage && (
+                <div className="tracking-preview">
+                  <img src={selectedImage} alt="Selected tracking attachment preview" />
+                </div>
+              )}
+
+              <div className="tracking-location-row">
+                <div>
+                  <label htmlFor="tracking-latitude">Latitude</label>
+                  <input
+                    id="tracking-latitude"
+                    value={latitude}
+                    onChange={(event) => setLatitude(event.target.value)}
+                    placeholder="49.282700"
+                  />
+                </div>
+                <div>
+                  <label htmlFor="tracking-longitude">Longitude</label>
+                  <input
+                    id="tracking-longitude"
+                    value={longitude}
+                    onChange={(event) => setLongitude(event.target.value)}
+                    placeholder="-123.120700"
+                  />
+                </div>
+                <button className="tracking-secondary-button" onClick={getCurrentLocation} disabled={isLocating}>
+                  {isLocating ? 'Getting GPS…' : 'Use Current GPS'}
+                </button>
+              </div>
+              {accuracy !== null && <p className="tracking-accuracy">GPS accuracy: about {Math.round(accuracy)} meters.</p>}
+
+              <label htmlFor="tracking-relays">Public relays</label>
+              <textarea
+                id="tracking-relays"
+                value={relayText}
+                onChange={(event) => setRelayText(event.target.value)}
+                rows={5}
+              />
+              <small>Separate relay URLs with commas, spaces, or new lines. Publishing will fan out to every relay listed.</small>
+
+              <div className="tracking-actions">
+                <button className="tracking-secondary-button" onClick={() => setIsPostModalOpen(false)} disabled={isPublishing}>
+                  Cancel
+                </button>
+                <button className="tracking-primary-button" onClick={publishTrackingPost} disabled={isPublishing || !pubkey}>
+                  {isPublishing ? 'Publishing…' : `Publish to ${relays.length} Relay${relays.length === 1 ? '' : 's'}`}
+                </button>
+              </div>
+            </div>
+          </section>
+        </div>
       )}
     </main>
   );

--- a/src/pages/Tracking.tsx
+++ b/src/pages/Tracking.tsx
@@ -1,0 +1,416 @@
+import React, { useMemo, useState } from 'react';
+import './Tracking.css';
+import { useNotification } from '../context/NotificationContext';
+
+type NostrEvent = {
+  id?: string;
+  pubkey: string;
+  created_at: number;
+  kind: number;
+  tags: string[][];
+  content: string;
+  sig?: string;
+};
+
+type NostrProvider = {
+  getPublicKey: () => Promise<string>;
+  signEvent: (event: NostrEvent) => Promise<NostrEvent>;
+};
+
+type PublishResult = {
+  relay: string;
+  ok: boolean;
+  message: string;
+};
+
+declare global {
+  interface Window {
+    nostr?: NostrProvider;
+  }
+}
+
+const DEFAULT_RELAYS = [
+  'wss://relay.damus.io',
+  'wss://nos.lol',
+  'wss://relay.primal.net',
+  'wss://relay.snort.social',
+  'wss://nostr.wine',
+];
+
+const GEOHASH_BASE32 = '0123456789bcdefghjkmnpqrstuvwxyz';
+
+const toHex = (buffer: ArrayBuffer) => Array.from(new Uint8Array(buffer))
+  .map((byte) => byte.toString(16).padStart(2, '0'))
+  .join('');
+
+const getEventHash = async (event: NostrEvent) => {
+  const serialized = JSON.stringify([
+    0,
+    event.pubkey,
+    event.created_at,
+    event.kind,
+    event.tags,
+    event.content,
+  ]);
+  const encoded = new TextEncoder().encode(serialized);
+  const digest = await crypto.subtle.digest('SHA-256', encoded);
+  return toHex(digest);
+};
+
+const encodeGeohash = (latitude: number, longitude: number, precision = 9) => {
+  let evenBit = true;
+  let bit = 0;
+  let ch = 0;
+  let geohash = '';
+  const latRange = [-90, 90];
+  const lonRange = [-180, 180];
+
+  while (geohash.length < precision) {
+    if (evenBit) {
+      const mid = (lonRange[0] + lonRange[1]) / 2;
+      if (longitude >= mid) {
+        ch = (ch << 1) + 1;
+        lonRange[0] = mid;
+      } else {
+        ch <<= 1;
+        lonRange[1] = mid;
+      }
+    } else {
+      const mid = (latRange[0] + latRange[1]) / 2;
+      if (latitude >= mid) {
+        ch = (ch << 1) + 1;
+        latRange[0] = mid;
+      } else {
+        ch <<= 1;
+        latRange[1] = mid;
+      }
+    }
+
+    evenBit = !evenBit;
+    if (++bit === 5) {
+      geohash += GEOHASH_BASE32[ch];
+      bit = 0;
+      ch = 0;
+    }
+  }
+
+  return geohash;
+};
+
+const normalizeRelays = (relayText: string) => relayText
+  .split(/\s|,/)
+  .map((relay) => relay.trim())
+  .filter(Boolean)
+  .filter((relay, index, relays) => relays.indexOf(relay) === index);
+
+const publishToRelay = (relay: string, event: NostrEvent): Promise<PublishResult> => new Promise((resolve) => {
+  let settled = false;
+  const socket = new WebSocket(relay);
+  const timeout = window.setTimeout(() => {
+    if (!settled) {
+      settled = true;
+      socket.close();
+      resolve({ relay, ok: false, message: 'Timed out waiting for relay acknowledgement.' });
+    }
+  }, 10000);
+
+  const settle = (ok: boolean, message: string) => {
+    if (settled) return;
+    settled = true;
+    window.clearTimeout(timeout);
+    socket.close();
+    resolve({ relay, ok, message });
+  };
+
+  socket.onopen = () => socket.send(JSON.stringify(['EVENT', event]));
+  socket.onerror = () => settle(false, 'Connection failed.');
+  socket.onmessage = (message) => {
+    try {
+      const payload = JSON.parse(message.data);
+      if (payload[0] === 'OK' && payload[1] === event.id) {
+        settle(Boolean(payload[2]), payload[3] || (payload[2] ? 'Accepted.' : 'Rejected.'));
+      }
+      if (payload[0] === 'NOTICE') {
+        settle(false, payload[1] || 'Relay returned a notice.');
+      }
+    } catch {
+      settle(false, 'Relay returned an invalid response.');
+    }
+  };
+});
+
+export const Tracking = () => {
+  const { showNotification } = useNotification();
+  const [content, setContent] = useState('');
+  const [photoUrl, setPhotoUrl] = useState('');
+  const [photoPreview, setPhotoPreview] = useState('');
+  const [latitude, setLatitude] = useState('');
+  const [longitude, setLongitude] = useState('');
+  const [accuracy, setAccuracy] = useState<number | null>(null);
+  const [relayText, setRelayText] = useState(DEFAULT_RELAYS.join('\n'));
+  const [pubkey, setPubkey] = useState('');
+  const [isLocating, setIsLocating] = useState(false);
+  const [isPublishing, setIsPublishing] = useState(false);
+  const [results, setResults] = useState<PublishResult[]>([]);
+
+  const relays = useMemo(() => normalizeRelays(relayText), [relayText]);
+  const hasNostrExtension = typeof window !== 'undefined' && Boolean(window.nostr);
+  const selectedImage = photoPreview || photoUrl;
+
+  const connectNostr = async () => {
+    if (!window.nostr) {
+      showNotification('Install or enable a Nostr browser extension that supports NIP-07 signing.', 'error');
+      return;
+    }
+
+    try {
+      const publicKey = await window.nostr.getPublicKey();
+      setPubkey(publicKey);
+      showNotification('Nostr signer connected.', 'success');
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      showNotification(`Could not connect Nostr signer: ${message}`, 'error');
+    }
+  };
+
+  const getCurrentLocation = () => {
+    if (!navigator.geolocation) {
+      showNotification('Geolocation is not available in this browser.', 'error');
+      return;
+    }
+
+    setIsLocating(true);
+    navigator.geolocation.getCurrentPosition(
+      (position) => {
+        setLatitude(position.coords.latitude.toFixed(6));
+        setLongitude(position.coords.longitude.toFixed(6));
+        setAccuracy(position.coords.accuracy);
+        setIsLocating(false);
+        showNotification('GPS location added to your tracking post.', 'success');
+      },
+      (error) => {
+        setIsLocating(false);
+        showNotification(`Unable to get GPS location: ${error.message}`, 'error');
+      },
+      { enableHighAccuracy: true, timeout: 15000, maximumAge: 30000 },
+    );
+  };
+
+  const handlePhotoFile = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    if (file.size > 250000) {
+      showNotification('Large files are often rejected by public relays. Use a hosted photo URL for best results.', 'error');
+    }
+
+    const reader = new FileReader();
+    reader.onload = () => {
+      const result = String(reader.result || '');
+      setPhotoPreview(result);
+      setPhotoUrl(result);
+    };
+    reader.readAsDataURL(file);
+  };
+
+  const buildEvent = async () => {
+    if (!window.nostr) throw new Error('No Nostr signer found.');
+    if (!pubkey) throw new Error('Connect your Nostr signer first.');
+
+    const lat = Number(latitude);
+    const lon = Number(longitude);
+    if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
+      throw new Error('Add a valid GPS latitude and longitude before publishing.');
+    }
+
+    const trimmedContent = content.trim();
+    if (!trimmedContent && !photoUrl.trim()) {
+      throw new Error('Write content or add a photo before publishing.');
+    }
+
+    const mapUrl = `https://www.openstreetmap.org/?mlat=${lat}&mlon=${lon}#map=17/${lat}/${lon}`;
+    const image = photoUrl.trim();
+    const geohash = encodeGeohash(lat, lon);
+    const eventContent = [
+      trimmedContent,
+      image,
+      `📍 ${lat.toFixed(6)}, ${lon.toFixed(6)}`,
+      mapUrl,
+    ].filter(Boolean).join('\n\n');
+
+    const tags = [
+      ['client', 'AllTracks'],
+      ['t', 'alltracks'],
+      ['t', 'tracking'],
+      ['g', geohash],
+      ['location', lat.toFixed(6), lon.toFixed(6)],
+      ['r', mapUrl],
+      ['alt', 'AllTracks GPS tracking post with location metadata'],
+    ];
+
+    if (image) {
+      tags.push(['r', image]);
+      tags.push(['imeta', `url ${image}`]);
+    }
+
+    const unsignedEvent: NostrEvent = {
+      pubkey,
+      created_at: Math.floor(Date.now() / 1000),
+      kind: 1,
+      tags,
+      content: eventContent,
+    };
+
+    unsignedEvent.id = await getEventHash(unsignedEvent);
+    const signedEvent = await window.nostr.signEvent(unsignedEvent);
+    return { ...signedEvent, id: signedEvent.id || unsignedEvent.id };
+  };
+
+  const publishTrackingPost = async () => {
+    if (relays.length === 0) {
+      showNotification('Add at least one public relay.', 'error');
+      return;
+    }
+
+    setIsPublishing(true);
+    setResults([]);
+    try {
+      const event = await buildEvent();
+      const publishResults = await Promise.all(relays.map((relay) => publishToRelay(relay, event)));
+      setResults(publishResults);
+      const accepted = publishResults.filter((result) => result.ok).length;
+      if (accepted > 0) {
+        showNotification(`Tracking post published to ${accepted}/${publishResults.length} relays.`, 'success');
+        setContent('');
+      } else {
+        showNotification('No relays accepted the tracking post.', 'error');
+      }
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Unable to publish tracking post.';
+      showNotification(message, 'error');
+    } finally {
+      setIsPublishing(false);
+    }
+  };
+
+  return (
+    <main className="tracking-page">
+      <section className="tracking-hero">
+        <div>
+          <p className="tracking-eyebrow">Nostr GPS publishing</p>
+          <h1>Tracking</h1>
+          <p>
+            Share an AllTracks update with content, a photo reference, and GPS coordinates to multiple public Nostr relays.
+          </p>
+        </div>
+        <button className="tracking-secondary-button" onClick={connectNostr} disabled={!hasNostrExtension}>
+          {pubkey ? 'Signer Connected' : 'Connect Nostr Signer'}
+        </button>
+      </section>
+
+      {!hasNostrExtension && (
+        <div className="tracking-alert">
+          A Nostr browser signer such as Alby, nos2x, or another NIP-07 extension is required to sign and publish events.
+        </div>
+      )}
+
+      {pubkey && <div className="tracking-pubkey">Public key: {pubkey}</div>}
+
+      <section className="tracking-card">
+        <label htmlFor="tracking-content">Content</label>
+        <textarea
+          id="tracking-content"
+          value={content}
+          onChange={(event) => setContent(event.target.value)}
+          rows={5}
+          placeholder="What are you seeing on your track?"
+        />
+
+        <div className="tracking-grid">
+          <div>
+            <label htmlFor="tracking-photo-url">Photo URL</label>
+            <input
+              id="tracking-photo-url"
+              type="url"
+              value={photoUrl}
+              onChange={(event) => {
+                setPhotoUrl(event.target.value);
+                setPhotoPreview('');
+              }}
+              placeholder="https://example.com/photo.jpg"
+            />
+            <small>Public relays store Nostr events, not media files. A hosted image URL is recommended.</small>
+          </div>
+          <div>
+            <label htmlFor="tracking-photo-file">Or attach a small photo as a data URI</label>
+            <input id="tracking-photo-file" type="file" accept="image/*" onChange={handlePhotoFile} />
+            <small>Use small images only; many relays reject large events.</small>
+          </div>
+        </div>
+
+        {selectedImage && (
+          <div className="tracking-preview">
+            <img src={selectedImage} alt="Selected tracking attachment preview" />
+          </div>
+        )}
+
+        <div className="tracking-location-row">
+          <div>
+            <label htmlFor="tracking-latitude">Latitude</label>
+            <input
+              id="tracking-latitude"
+              value={latitude}
+              onChange={(event) => setLatitude(event.target.value)}
+              placeholder="49.282700"
+            />
+          </div>
+          <div>
+            <label htmlFor="tracking-longitude">Longitude</label>
+            <input
+              id="tracking-longitude"
+              value={longitude}
+              onChange={(event) => setLongitude(event.target.value)}
+              placeholder="-123.120700"
+            />
+          </div>
+          <button className="tracking-secondary-button" onClick={getCurrentLocation} disabled={isLocating}>
+            {isLocating ? 'Getting GPS…' : 'Use Current GPS'}
+          </button>
+        </div>
+        {accuracy !== null && <p className="tracking-accuracy">GPS accuracy: about {Math.round(accuracy)} meters.</p>}
+
+        <label htmlFor="tracking-relays">Public relays</label>
+        <textarea
+          id="tracking-relays"
+          value={relayText}
+          onChange={(event) => setRelayText(event.target.value)}
+          rows={5}
+        />
+        <small>Separate relay URLs with commas, spaces, or new lines. Publishing will fan out to every relay listed.</small>
+
+        <div className="tracking-actions">
+          <button className="tracking-primary-button" onClick={publishTrackingPost} disabled={isPublishing || !pubkey}>
+            {isPublishing ? 'Publishing…' : `Publish to ${relays.length} Relay${relays.length === 1 ? '' : 's'}`}
+          </button>
+        </div>
+      </section>
+
+      {results.length > 0 && (
+        <section className="tracking-card">
+          <h2>Relay results</h2>
+          <ul className="tracking-results">
+            {results.map((result) => (
+              <li key={result.relay} className={result.ok ? 'tracking-result-ok' : 'tracking-result-error'}>
+                <strong>{result.ok ? 'Accepted' : 'Rejected'}</strong>
+                <span>{result.relay}</span>
+                <small>{result.message}</small>
+              </li>
+            ))}
+          </ul>
+        </section>
+      )}
+    </main>
+  );
+};
+
+export default Tracking;


### PR DESCRIPTION
### Motivation
- Add a dedicated "Tracking" UI so users can publish photo/content with GPS location using Nostr relays. 
- Provide a lightweight NIP-07 signer flow and fan-out publishing to multiple public relays with location metadata. 
- Surface the new capability prominently by adding a first-item entry in desktop and mobile navigation. 

### Description
- Add a new page `src/pages/Tracking.tsx` and styles `src/pages/Tracking.css` implementing a NIP-07 signer connection, current-GPS lookup, photo URL or small file attachment, geohash/location tags, and signed Nostr event creation. 
- Implement relay fan-out via WebSocket to multiple public relays with per-relay acknowledgement handling and UI for results. 
- Wire the page into the router by importing `Tracking` in `src/App.tsx` and exposing the route `/tracking`. 
- Add the `Tracking` link as the first desktop nav item in `src/components/Navbar.tsx` and as the first item in the mobile dropdown in `src/components/DropdownMenu.tsx`, plus small related lint-safe tweaks to imports/unused vars in those files. 

### Testing
- Ran `npm run build` which completed successfully and produced the production bundles. 
- Ran targeted ESLint on the affected files with `npx eslint src/pages/Tracking.tsx src/App.tsx src/components/Navbar.tsx src/components/DropdownMenu.tsx` and the modified files passed the targeted checks. 
- Ran project-wide `npm run lint` which failed due to many existing unrelated lint errors in other files (these pre-existing issues were not introduced by this change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d8cc632148330a9c1791c4376869b)