### PR TITLE
Add West Coast Trail Trail Hub MVP

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -23,6 +23,7 @@ import Everpeace from './pages/Everpeace';
 import { Trackathons } from './pages/Trackathons';
 import { TrackathonDetail } from './pages/TrackathonDetail';
 import { Tracking } from './pages/Tracking';
+import { TrailHub } from './pages/TrailHub';
 
 import { NotificationProvider } from './context/NotificationContext';
 import { StatsProvider } from './context/StatsContext';
@@ -40,6 +41,7 @@ function App() {
                 <Route path="/" element={<MainApp />} />
                 <Route path="/tracking" element={<Tracking />} />
                 <Route path="/trails" element={<Trails />} />
+                <Route path="/trail/west-coast-trail" element={<TrailHub />} />
                 <Route path="/events" element={<Events />} />
                 <Route path="/track/:trackId" element={<TrackPage />} />
                 <Route path="/event/:eventId" element={<EventPage />} />

--- a/src/pages/TrailHub.css
+++ b/src/pages/TrailHub.css
@@ -1,0 +1,268 @@
+.trail-hub-page {
+  min-height: 100vh;
+  padding: 32px;
+  color: #172033;
+  background: linear-gradient(180deg, #f3f8f4 0%, #ffffff 42%, #eef5f8 100%);
+}
+
+.trail-hub-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.6fr) minmax(280px, 0.8fr);
+  gap: 24px;
+  align-items: stretch;
+  max-width: 1180px;
+  margin: 0 auto 24px;
+}
+
+.trail-hub-back-link {
+  display: inline-flex;
+  margin-bottom: 16px;
+  color: #25635a;
+  font-weight: 700;
+  text-decoration: none;
+}
+
+.trail-hub-eyebrow {
+  margin: 0 0 8px;
+  color: #47756f;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.trail-hub-hero h1 {
+  margin: 0;
+  font-size: clamp(2.4rem, 8vw, 5rem);
+  line-height: 0.95;
+}
+
+.trail-hub-subtitle {
+  max-width: 760px;
+  margin: 20px 0 0;
+  color: #475569;
+  font-size: 1.05rem;
+  line-height: 1.7;
+}
+
+.trail-hub-actions,
+.trail-hub-mini-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 22px;
+}
+
+.trail-hub-actions button,
+.trail-hub-mini-actions button {
+  border: 0;
+  border-radius: 999px;
+  padding: 11px 18px;
+  color: white;
+  background: #1f6f61;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.trail-hub-actions button.secondary,
+.trail-hub-mini-actions button {
+  color: #1f3b36;
+  background: #e2eee8;
+}
+
+.trail-hub-summary-card,
+.trail-hub-stat-card,
+.trail-hub-map-card,
+.trail-hub-detail-card,
+.trail-hub-panel,
+.trail-hub-roadmap {
+  border: 1px solid rgba(37, 99, 90, 0.14);
+  border-radius: 28px;
+  background: rgba(255, 255, 255, 0.86);
+  box-shadow: 0 18px 48px rgba(32, 75, 68, 0.08);
+}
+
+.trail-hub-summary-card {
+  padding: 28px;
+}
+
+.trail-hub-summary-card .material-icons {
+  color: #1f6f61;
+  font-size: 42px;
+}
+
+.trail-hub-summary-card h2,
+.trail-hub-detail-card h2,
+.trail-hub-panel h2,
+.trail-hub-roadmap h2,
+.trail-hub-section-heading h2 {
+  margin: 0;
+}
+
+.trail-hub-summary-card p,
+.trail-hub-detail-card p {
+  color: #52616f;
+  line-height: 1.6;
+}
+
+.trail-hub-stats {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+  max-width: 1180px;
+  margin: 0 auto 24px;
+}
+
+.trail-hub-stat-card {
+  padding: 18px;
+}
+
+.trail-hub-stat-card span {
+  display: block;
+  color: #66817c;
+  font-size: 0.85rem;
+  font-weight: 700;
+}
+
+.trail-hub-stat-card strong {
+  display: block;
+  margin-top: 8px;
+  font-size: 1.45rem;
+}
+
+.trail-hub-grid,
+.trail-hub-content-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(300px, 0.75fr);
+  gap: 24px;
+  max-width: 1180px;
+  margin: 0 auto 24px;
+}
+
+.trail-hub-map-card,
+.trail-hub-detail-card,
+.trail-hub-panel,
+.trail-hub-roadmap {
+  padding: 22px;
+}
+
+.trail-hub-section-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.trail-hub-live-pill,
+.trail-hub-point-meta span,
+.trail-hub-tags span,
+.trail-hub-discussion-card span {
+  display: inline-flex;
+  align-items: center;
+  border-radius: 999px;
+  padding: 6px 10px;
+  color: #1f6f61;
+  background: #e5f4ef;
+  font-size: 0.76rem;
+  font-weight: 800;
+}
+
+.trail-hub-map {
+  width: 100%;
+  height: 520px;
+  overflow: hidden;
+  border-radius: 22px;
+}
+
+.trail-hub-point-meta,
+.trail-hub-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 14px 0;
+}
+
+.trail-hub-tags span {
+  color: #394b59;
+  background: #edf2f7;
+}
+
+.trail-hub-segments,
+.trail-hub-discussions {
+  display: grid;
+  gap: 12px;
+}
+
+.trail-hub-segment-card,
+.trail-hub-discussion-card {
+  border: 1px solid #e5edf0;
+  border-radius: 18px;
+  padding: 16px;
+  background: #fbfdfc;
+}
+
+.trail-hub-segment-card div {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.trail-hub-segment-card span,
+.trail-hub-discussion-card p,
+.trail-hub-segment-card small {
+  color: #64748b;
+}
+
+.trail-hub-segment-card p {
+  margin: 10px 0 8px;
+  color: #334155;
+}
+
+.trail-hub-discussion-card h3 {
+  margin: 10px 0 6px;
+  font-size: 1rem;
+}
+
+.trail-hub-roadmap {
+  max-width: 1180px;
+  margin: 0 auto;
+}
+
+.trail-hub-roadmap-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 12px;
+  margin-top: 18px;
+}
+
+.trail-hub-roadmap-grid div {
+  display: grid;
+  gap: 8px;
+  border-radius: 18px;
+  padding: 16px;
+  background: #f7faf9;
+}
+
+.trail-hub-roadmap-grid span {
+  color: #64748b;
+  line-height: 1.5;
+}
+
+@media (max-width: 900px) {
+  .trail-hub-page {
+    padding: 18px;
+  }
+
+  .trail-hub-hero,
+  .trail-hub-grid,
+  .trail-hub-content-grid,
+  .trail-hub-stats,
+  .trail-hub-roadmap-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .trail-hub-map {
+    height: 420px;
+  }
+}

--- a/src/pages/TrailHub.tsx
+++ b/src/pages/TrailHub.tsx
@@ -1,0 +1,319 @@
+import React, { useMemo, useState } from 'react';
+import { Link } from 'react-router-dom';
+import { MapContainer, Marker, Polyline, Popup, TileLayer } from 'react-leaflet';
+import { Icon, LatLngTuple } from 'leaflet';
+import markerIcon from 'leaflet/dist/images/marker-icon.png';
+import markerShadow from 'leaflet/dist/images/marker-shadow.png';
+import 'leaflet/dist/leaflet.css';
+import './TrailHub.css';
+
+type TrailPoint = {
+  id: string;
+  name: string;
+  km: number;
+  type: 'trailhead' | 'camp' | 'poi' | 'hazard';
+  position: LatLngTuple;
+  tags: string[];
+  notes: string;
+};
+
+type TrailSegment = {
+  from: string;
+  to: string;
+  distance: string;
+  terrain: string;
+  planningNote: string;
+};
+
+type Discussion = {
+  title: string;
+  channel: string;
+  replies: number;
+  lastActive: string;
+};
+
+const wctPath: LatLngTuple[] = [
+  [48.8747, -124.5915],
+  [48.9071, -124.6804],
+  [48.9382, -124.7276],
+  [48.973, -124.802],
+  [49.0008, -124.8564],
+  [49.039, -124.8808],
+  [49.0798, -124.9481],
+  [49.1167, -125.0206],
+  [49.1738, -125.1156],
+  [49.2474, -125.2134],
+];
+
+const points: TrailPoint[] = [
+  {
+    id: 'gordon-river',
+    name: 'Gordon River Trailhead',
+    km: 75,
+    type: 'trailhead',
+    position: [48.8747, -124.5915],
+    tags: ['NOBO start', 'orientation', 'ferry access'],
+    notes: 'Southern access point. Good place to surface permits, shuttle notes, and start logistics.',
+  },
+  {
+    id: 'thrasher-cove',
+    name: 'Thrasher Cove',
+    km: 70,
+    type: 'camp',
+    position: [48.9071, -124.6804],
+    tags: ['camp', 'beach', 'steep access'],
+    notes: 'Useful for early NOBO pacing notes and user-submitted recent conditions.',
+  },
+  {
+    id: 'owen-point',
+    name: 'Owen Point',
+    km: 67,
+    type: 'poi',
+    position: [48.9382, -124.7276],
+    tags: ['tide aware', 'sea caves', 'photo spot'],
+    notes: 'A tide-sensitive highlight. The hub can attach tide windows and community confirmations here.',
+  },
+  {
+    id: 'walbran-creek',
+    name: 'Walbran Creek',
+    km: 53,
+    type: 'camp',
+    position: [49.0008, -124.8564],
+    tags: ['camp', 'water', 'bear cache'],
+    notes: 'Camp detail page candidate: tent spots, water source, toilets, photos, and comments.',
+  },
+  {
+    id: 'carmanah',
+    name: 'Carmanah Lighthouse Area',
+    km: 44,
+    type: 'poi',
+    position: [49.039, -124.8808],
+    tags: ['landmark', 'history', 'rest stop'],
+    notes: 'Good example for POI pages with history, media, and nearby hazards.',
+  },
+  {
+    id: 'tsusiat-falls',
+    name: 'Tsusiat Falls',
+    km: 25,
+    type: 'camp',
+    position: [49.1167, -125.0206],
+    tags: ['camp', 'waterfall', 'popular'],
+    notes: 'A natural MVP showcase for media, camp reports, and crowding discussions.',
+  },
+  {
+    id: 'pachena-bay',
+    name: 'Pachena Bay Trailhead',
+    km: 0,
+    type: 'trailhead',
+    position: [49.2474, -125.2134],
+    tags: ['SOBO start', 'NOBO finish', 'trailhead'],
+    notes: 'Northern access point. Useful for finish logistics, shuttle coordination, and completion posts.',
+  },
+];
+
+const segments: TrailSegment[] = [
+  {
+    from: 'Gordon River',
+    to: 'Thrasher Cove',
+    distance: '~5 km',
+    terrain: 'Forest, ladders, beach access',
+    planningNote: 'Good first-day decision point for NOBO hikers; keep tide and fatigue notes visible.',
+  },
+  {
+    from: 'Thrasher Cove',
+    to: 'Walbran Creek',
+    distance: '~17 km',
+    terrain: 'Beach routes, rocks, forest bypasses',
+    planningNote: 'Segment cards should expose tide-sensitive alternatives and recent hazard reports.',
+  },
+  {
+    from: 'Walbran Creek',
+    to: 'Carmanah',
+    distance: '~9 km',
+    terrain: 'Mixed beach and forest',
+    planningNote: 'Good place to show POI media, water notes, and lighthouse-area discussions.',
+  },
+  {
+    from: 'Carmanah',
+    to: 'Tsusiat Falls',
+    distance: '~19 km',
+    terrain: 'Boardwalk, cable cars, beach',
+    planningNote: 'Candidate for daily itinerary splitting and campsite recommendation logic.',
+  },
+  {
+    from: 'Tsusiat Falls',
+    to: 'Pachena Bay',
+    distance: '~25 km',
+    terrain: 'Forest trail, beach sections',
+    planningNote: 'Finish-day logistics, pickup coordination, and completion timeline posts fit here.',
+  },
+];
+
+const discussions: Discussion[] = [
+  { title: 'Anyone starting NOBO this week?', channel: 'Planning', replies: 12, lastActive: '2h ago' },
+  { title: 'Owen Point tide window reports', channel: 'Conditions', replies: 8, lastActive: '5h ago' },
+  { title: 'Best 6-day campsite split?', channel: 'Itinerary', replies: 18, lastActive: '1d ago' },
+  { title: 'Ride share from Victoria to Gordon River', channel: 'Ride Share', replies: 5, lastActive: '1d ago' },
+];
+
+const stats = [
+  { label: 'Distance', value: '75 km' },
+  { label: 'Typical Plan', value: '6-8 days' },
+  { label: 'Direction', value: 'NOBO / SOBO' },
+  { label: 'Focus', value: 'Tide + Camps' },
+];
+
+const pointIcon = new Icon({
+  iconUrl: markerIcon,
+  shadowUrl: markerShadow,
+  iconSize: [25, 41],
+  iconAnchor: [12, 41],
+});
+
+export const TrailHub = () => {
+  const [selectedPointId, setSelectedPointId] = useState(points[0].id);
+  const selectedPoint = useMemo(
+    () => points.find((point) => point.id === selectedPointId) ?? points[0],
+    [selectedPointId]
+  );
+
+  return (
+    <div className="trail-hub-page">
+      <section className="trail-hub-hero">
+        <div>
+          <Link to="/trails" className="trail-hub-back-link">← Trails</Link>
+          <p className="trail-hub-eyebrow">Trail Hub MVP</p>
+          <h1>West Coast Trail</h1>
+          <p className="trail-hub-subtitle">
+            A first version of a living trail space: route overview, key points, segment planning,
+            conditions, and hiker discussions in one place.
+          </p>
+          <div className="trail-hub-actions">
+            <button>Plan Itinerary</button>
+            <button className="secondary">Report Condition</button>
+          </div>
+        </div>
+        <div className="trail-hub-summary-card">
+          <span className="material-icons">terrain</span>
+          <h2>Trail OS Starter</h2>
+          <p>
+            Static WCT seed data today. Later this can connect to official notices, tide APIs,
+            user tracks, media, and ICEvent trip plans.
+          </p>
+        </div>
+      </section>
+
+      <section className="trail-hub-stats">
+        {stats.map((stat) => (
+          <div key={stat.label} className="trail-hub-stat-card">
+            <span>{stat.label}</span>
+            <strong>{stat.value}</strong>
+          </div>
+        ))}
+      </section>
+
+      <section className="trail-hub-grid">
+        <div className="trail-hub-map-card">
+          <div className="trail-hub-section-heading">
+            <div>
+              <p className="trail-hub-eyebrow">Interactive Route</p>
+              <h2>Route, camps, POIs, hazards</h2>
+            </div>
+            <span className="trail-hub-live-pill">Prototype</span>
+          </div>
+          <MapContainer center={[49.04, -124.91]} zoom={9} className="trail-hub-map">
+            <TileLayer
+              url="https://{s}.tile.opentopomap.org/{z}/{x}/{y}.png"
+              attribution=""
+              maxZoom={17}
+            />
+            <Polyline positions={wctPath} weight={5} opacity={0.8} />
+            {points.map((point) => (
+              <Marker
+                key={point.id}
+                position={point.position}
+                icon={pointIcon}
+                eventHandlers={{ click: () => setSelectedPointId(point.id) }}
+              >
+                <Popup>
+                  <strong>{point.name}</strong>
+                  <p>{point.tags.join(' · ')}</p>
+                </Popup>
+              </Marker>
+            ))}
+          </MapContainer>
+        </div>
+
+        <aside className="trail-hub-detail-card">
+          <p className="trail-hub-eyebrow">Selected Point</p>
+          <h2>{selectedPoint.name}</h2>
+          <div className="trail-hub-point-meta">
+            <span>KM {selectedPoint.km}</span>
+            <span>{selectedPoint.type}</span>
+          </div>
+          <p>{selectedPoint.notes}</p>
+          <div className="trail-hub-tags">
+            {selectedPoint.tags.map((tag) => <span key={tag}>{tag}</span>)}
+          </div>
+          <div className="trail-hub-mini-actions">
+            <button>Add photo</button>
+            <button>Add comment</button>
+            <button>Save to itinerary</button>
+          </div>
+        </aside>
+      </section>
+
+      <section className="trail-hub-content-grid">
+        <div className="trail-hub-panel">
+          <div className="trail-hub-section-heading">
+            <div>
+              <p className="trail-hub-eyebrow">Segments</p>
+              <h2>Planning breakdown</h2>
+            </div>
+          </div>
+          <div className="trail-hub-segments">
+            {segments.map((segment) => (
+              <article key={`${segment.from}-${segment.to}`} className="trail-hub-segment-card">
+                <div>
+                  <strong>{segment.from} → {segment.to}</strong>
+                  <span>{segment.distance}</span>
+                </div>
+                <p>{segment.terrain}</p>
+                <small>{segment.planningNote}</small>
+              </article>
+            ))}
+          </div>
+        </div>
+
+        <div className="trail-hub-panel">
+          <div className="trail-hub-section-heading">
+            <div>
+              <p className="trail-hub-eyebrow">Community</p>
+              <h2>Hiker discussions</h2>
+            </div>
+          </div>
+          <div className="trail-hub-discussions">
+            {discussions.map((discussion) => (
+              <article key={discussion.title} className="trail-hub-discussion-card">
+                <span>{discussion.channel}</span>
+                <h3>{discussion.title}</h3>
+                <p>{discussion.replies} replies · active {discussion.lastActive}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="trail-hub-roadmap">
+        <p className="trail-hub-eyebrow">Next integrations</p>
+        <h2>What this page should connect to next</h2>
+        <div className="trail-hub-roadmap-grid">
+          <div><strong>Tides</strong><span>Attach passable windows to beach POIs.</span></div>
+          <div><strong>Conditions</strong><span>User reports with confirmation counts.</span></div>
+          <div><strong>Itinerary</strong><span>Export daily plan to ICEvent calendar.</span></div>
+          <div><strong>Tracks</strong><span>Overlay real GPX/KML tracks and checkpoint media.</span></div>
+        </div>
+      </section>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- Adds a new `/trail/west-coast-trail` Trail Hub MVP page.
- Shows a WCT overview, route map, key points, segment planning cards, community discussion mock data, and next-integration roadmap.
- Wires the page into React Router.

## Notes
- This is intentionally static seed data for the first version.
- Next steps: connect conditions/discussions/media to backend data, add tide integration, and expose the page from the Trails list/navigation.

## Testing
- Not run in this environment.