### PR TITLE
Add trail detail links to map popups

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,7 +41,7 @@ function App() {
                 <Route path="/" element={<MainApp />} />
                 <Route path="/tracking" element={<Tracking />} />
                 <Route path="/trails" element={<Trails />} />
-                <Route path="/trail/west-coast-trail" element={<TrailHub />} />
+                <Route path="/trail/:trailId" element={<TrailHub />} />
                 <Route path="/events" element={<Events />} />
                 <Route path="/track/:trackId" element={<TrackPage />} />
                 <Route path="/event/:eventId" element={<EventPage />} />

--- a/src/pages/Trails.css
+++ b/src/pages/Trails.css
@@ -155,21 +155,39 @@
 
 .trail-actions {
   display: flex;
+  flex-wrap: wrap;
   gap: 8px;
   margin-top: 8px;
 }
 
 .icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
   padding: 8px;
   border: none;
+  border-radius: 6px;
   background: none;
   cursor: pointer;
   color: #007AFF;
+  text-decoration: none;
 }
 
 .icon-button:hover {
   color: #0056b3;
+  background: rgba(0, 122, 255, 0.08);
 }
 .icon-button.active {
   color: #ff4400;
+}
+
+.trail-detail-link {
+  padding-inline: 10px;
+  background: rgba(0, 122, 255, 0.1);
+  font-weight: 600;
+}
+
+.trail-detail-link__text {
+  font-size: 12px;
 }

--- a/src/pages/Trails.tsx
+++ b/src/pages/Trails.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
+import { Link } from 'react-router-dom';
 
 import { Spinner } from '../components/Spinner';
 import './Trails.css';
@@ -201,9 +202,20 @@ export const Trails = () => {
                     <span>{trail.elevationGain} m</span>
                   </div>
                   <div className="trail-actions">
+                    <Link
+                      to={`/trail/${trail.id}`}
+                      className="icon-button trail-detail-link"
+                      title="Open trail details"
+                      aria-label={`Open details for ${trail.name}`}
+                    >
+                      <span className="material-icons">open_in_new</span>
+                      <span className="trail-detail-link__text">Details</span>
+                    </Link>
                     <button
                       className={`icon-button ${selectedTrailId === trail.id ? 'active' : ''}`}
                       onClick={() => handleTrailToggle(trail)}
+                      title="Show route on map"
+                      aria-label={`Show route for ${trail.name}`}
                     >
                       <span className="material-icons">route</span>
                     </button>
@@ -211,6 +223,8 @@ export const Trails = () => {
                       href={trail.trailfile.url}
                       download
                       className="icon-button"
+                      title="Download trail file"
+                      aria-label={`Download ${trail.name} trail file`}
                     >
                       <span className="material-icons">download</span>
                     </a>
@@ -232,4 +246,3 @@ export const Trails = () => {
     </div>
   );
 };
-


### PR DESCRIPTION
## Summary
- Adds a Details link to each trail marker popup on the Trails map.
- Links each trail to `/trail/:trailId`.
- Changes the TrailHub route from the WCT-only path to a generic detail route.
- Adds accessible labels/titles and popup link styling.

## Notes
- The current detail page still renders the existing TrailHub MVP content. This PR wires the navigation path first so the next step can load real trail data by `trailId`.

## Testing
- Not run in this environment.