### PR TITLE
Make profile trail rows clickable and accessible (open trail detail)

### DIFF
--- a/src/components/Trails.css
+++ b/src/components/Trails.css
@@ -70,11 +70,18 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  cursor: pointer;
 }
 
-.trail-item:hover {
+.trail-item:hover,
+.trail-item:focus-visible {
   transform: translateY(-2px);
   box-shadow: 0 4px 8px rgba(0,0,0,0.1);
+}
+
+.trail-item:focus-visible {
+  outline: 2px solid #007bff;
+  outline-offset: 3px;
 }
 
 .trail-info {

--- a/src/components/Trails.tsx
+++ b/src/components/Trails.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { User, setDoc, listDocs, uploadFile } from "@junobuild/core";
 import { CreateTrail } from './CreateTrail';
 import './Trails.css';
@@ -18,6 +19,7 @@ export const Trails: React.FC = () => {
         wallet, principal
     } } = useGlobalContext();
     const alltracks = useAlltracks();
+    const navigate = useNavigate();
 
     const [trails, setTrails] = React.useState<Trail[]>([]);
     const [showCreateModal, setShowCreateModal] = useState(false);
@@ -242,6 +244,10 @@ export const Trails: React.FC = () => {
         }
     };
 
+    const openTrailDetail = (trailId: number | string | bigint) => {
+        navigate(`/trail/${trailId.toString()}`);
+    };
+
     const toTrailForm = (trail: Trail): TrailForm => ({
         name: trail.name,
         description: trail.description,
@@ -277,7 +283,19 @@ export const Trails: React.FC = () => {
             <div className="trails-list">
                 {trails.length > 0 ? (
                     trails.map((trail) => (
-                        <div key={trail.id} className="trail-item">
+                        <div
+                            key={trail.id}
+                            className="trail-item"
+                            role="button"
+                            tabIndex={0}
+                            onClick={() => openTrailDetail(trail.id)}
+                            onKeyDown={(event) => {
+                                if (event.key === 'Enter' || event.key === ' ') {
+                                    event.preventDefault();
+                                    openTrailDetail(trail.id);
+                                }
+                            }}
+                        >
                             <div className="trail-info">
                                 <div className="trail-title">{trail.name}</div>
                                 <div className="trail-meta">
@@ -293,14 +311,20 @@ export const Trails: React.FC = () => {
                             <div className="trail-actions">
                                 <button
                                     className="trail-button edit"
-                                    onClick={() => setEditingTrail(trail)}
+                                    onClick={(event) => {
+                                        event.stopPropagation();
+                                        setEditingTrail(trail);
+                                    }}
                                 >
                                     <span className="material-icons">edit</span>
                                     Edit
                                 </button>
                                 <button
                                     className="trail-button delete"
-                                    onClick={() => setShowDeleteConfirm(BigInt(trail.id))}
+                                    onClick={(event) => {
+                                        event.stopPropagation();
+                                        setShowDeleteConfirm(BigInt(trail.id));
+                                    }}
                                 >
                                     <span className="material-icons">delete</span>
                                     Delete


### PR DESCRIPTION
### Motivation
- Enable opening a trail detail page from the Profile → Trails list and improve keyboard accessibility and discoverability for trail rows.

### Description
- Add `useNavigate` and `openTrailDetail` to navigate to `/trail/:trailId` when a trail row is clicked or activated with Enter/Space in `src/components/Trails.tsx`.
- Make each trail row `role="button"` and `tabIndex={0}` and handle `onKeyDown` for Enter/Space to support keyboard users.
- Prevent Edit/Delete buttons from bubbling to the row click handler by calling `event.stopPropagation()` in their `onClick` handlers.
- Update `src/components/Trails.css` to add `cursor: pointer` and `:focus-visible` outline styling so rows are visually discoverable and focusable.

### Testing
- Ran `npm run build` and the build completed successfully.
- Ran `npm run lint` and linting failed due to pre-existing repository-wide issues unrelated to this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a510708f3fc8330a437d5dea8e10b21)