### PR TITLE
Improve trails discovery page

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "allracks",
   "private": true,
   "version": "0.0.0",
+  "engines": {
+    "node": "24.x"
+  },
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/src/pages/Trails.css
+++ b/src/pages/Trails.css
@@ -1,89 +1,288 @@
 .trails-container {
-  padding: 20px;
+  min-height: calc(100vh - 60px);
+  padding: 28px;
+  color: #172033;
+  background: linear-gradient(180deg, #f4fbf6 0%, #ffffff 45%, #eef6f2 100%);
+}
+
+.trails-header,
+.trails-toolbar,
+.trails-map-card,
+.latest-trails-card,
+.trail-results-section {
   max-width: 1200px;
-  margin: 0 auto;
+  margin-left: auto;
+  margin-right: auto;
 }
 
 .trails-header {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 30px;
-}
-.trails-container {
-  padding: 20px;
-  height: calc(100vh - 60px);
+  margin-bottom: 18px;
 }
 
-.map-container {
+.trails-header h1 {
+  margin: 0;
+  color: #0f3d2d;
+  font-size: clamp(2.2rem, 6vw, 4.5rem);
+  line-height: 0.98;
+}
+
+.trails-header p:not(.trails-eyebrow) {
+  max-width: 760px;
+  margin: 14px 0 0;
+  color: #52616f;
+  line-height: 1.6;
+}
+
+.trails-eyebrow {
+  margin: 0 0 8px;
+  color: #1f7a55;
+  font-size: 0.78rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.trails-toolbar {
+  display: grid;
+  grid-template-columns: minmax(240px, 1fr) repeat(3, minmax(150px, 190px)) auto;
+  gap: 12px;
+  align-items: center;
+  padding: 14px;
+  margin-bottom: 18px;
+  border: 1px solid rgba(15, 92, 77, 0.12);
+  border-radius: 20px;
+  background: rgba(255, 255, 255, 0.9);
+  box-shadow: 0 14px 38px rgba(15, 61, 45, 0.08);
+}
+
+.trail-search-field {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  min-width: 0;
+  padding: 0 12px;
+  border: 1px solid #d8e7df;
+  border-radius: 999px;
+  background: #fbfffc;
+}
+
+.trail-search-field .material-icons {
+  color: #1f7a55;
+}
+
+.trail-search-field input,
+.trails-toolbar select {
   width: 100%;
-  height: 400px;
-  margin: 20px 0;
+  border: 0;
+  background: transparent;
+  color: #172033;
+  font: inherit;
+  outline: none;
+}
+
+.trail-search-field input {
+  padding: 12px 0;
+}
+
+.trails-toolbar select,
+.trails-toolbar button {
+  min-height: 44px;
+  padding: 0 12px;
+  border: 1px solid #d8e7df;
+  border-radius: 999px;
+  background: #fbfffc;
+}
+
+.trails-toolbar button {
+  color: #ffffff;
+  background: #0f5c4d;
+  font-weight: 800;
+  cursor: pointer;
+}
+
+.trails-alert {
+  max-width: 1200px;
+  margin: 0 auto 18px;
+  padding: 12px 14px;
+  border: 1px solid #ffd88a;
+  border-radius: 14px;
+  color: #755200;
+  background: #fff7e6;
+}
+
+.trails-content-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 1.45fr) minmax(300px, 0.65fr);
+  gap: 20px;
+  max-width: 1200px;
+  margin: 0 auto 22px;
+}
+
+.trails-map-card,
+.latest-trails-card,
+.trail-results-section {
+  padding: 20px;
+  border: 1px solid rgba(15, 92, 77, 0.12);
+  border-radius: 24px;
+  background: rgba(255, 255, 255, 0.92);
+  box-shadow: 0 18px 48px rgba(15, 61, 45, 0.08);
+}
+
+.trails-section-heading {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 14px;
+}
+
+.trails-section-heading h2 {
+  margin: 0;
+  color: #0f3d2d;
+}
+
+.trails-section-heading span,
+.latest-trail-item span {
+  color: #64748b;
+  font-size: 0.9rem;
+}
+
+.trails-loading {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  color: #1f7a55 !important;
+  font-weight: 800;
+}
+
+.spinning {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  100% {
+    transform: rotate(360deg);
+  }
 }
 
 .trails-map {
   width: 100%;
-  height: 100%;
-  border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  height: 560px;
+  border-radius: 18px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
 }
 
-.trails-grid {
-  margin-top: 20px;
+.latest-trails-list {
+  display: grid;
+  gap: 12px;
+}
+
+.latest-trail-item {
+  display: grid;
+  grid-template-columns: 72px 1fr;
+  gap: 12px;
+  align-items: center;
+  padding: 10px;
+  border: 1px solid #e5edf0;
+  border-radius: 18px;
+  color: inherit;
+  text-decoration: none;
+  background: #fbfdfc;
+  transition: transform 0.2s ease, border-color 0.2s ease;
+}
+
+.latest-trail-item:hover {
+  transform: translateY(-2px);
+  border-color: #9fd7bd;
+}
+
+.latest-trail-item img {
+  width: 72px;
+  height: 62px;
+  border-radius: 12px;
+  object-fit: cover;
+}
+
+.latest-trail-item strong,
+.latest-trail-item span {
+  display: block;
+}
+
+.latest-trail-item strong {
+  margin-bottom: 4px;
 }
 
 .trail-popup {
-  padding: 10px;
   min-width: 200px;
+  padding: 10px;
 }
 
 .trail-popup h3 {
-  margin: 0 0 10px 0;
+  margin: 0 0 10px;
+}
+
+.trail-stats,
+.trail-actions,
+.trail-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
 }
 
 .trail-stats {
-  display: flex;
-  gap: 10px;
-  margin-bottom: 8px;
+  color: #52616f;
+  font-size: 0.9rem;
 }
 
-.download-link {
-  display: inline-block;
-  margin-top: 10px;
-  padding: 5px 10px;
-  background: #d6d9dc;
-  color: white;
-  border-radius: 4px;
+.trail-actions {
+  margin-top: 12px;
+}
+
+.icon-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 4px;
+  padding: 8px;
+  border: none;
+  border-radius: 8px;
+  color: #0f5c4d;
+  background: none;
+  cursor: pointer;
   text-decoration: none;
 }
 
-.trails-filters select {
-  padding: 8px 16px;
-  border-radius: 4px;
-  border: 1px solid #ddd;
+.icon-button:hover,
+.icon-button.active,
+.trail-detail-link {
+  color: #ff4400;
+  background: rgba(255, 68, 0, 0.08);
 }
 
 .trails-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(300px, 1fr));
-  gap: 20px;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 18px;
 }
 
 .trail-card {
-  border-radius: 8px;
   overflow: hidden;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
+  border: 1px solid #e5edf0;
+  border-radius: 22px;
   background: white;
-  transition: transform 0.2s;
+  box-shadow: 0 12px 30px rgba(15, 61, 45, 0.07);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .trail-card:hover {
   transform: translateY(-4px);
+  box-shadow: 0 16px 36px rgba(15, 61, 45, 0.12);
 }
 
 .trail-image {
   position: relative;
-  height: 200px;
+  height: 190px;
 }
 
 .trail-image img {
@@ -94,95 +293,115 @@
 
 .difficulty-badge {
   position: absolute;
-  top: 10px;
-  right: 10px;
-  padding: 4px 8px;
-  border-radius: 4px;
+  top: 12px;
+  right: 12px;
+  padding: 6px 10px;
+  border-radius: 999px;
   color: white;
+  font-size: 0.78rem;
+  font-weight: 800;
   text-transform: capitalize;
 }
 
-.difficulty-badge.easy { background: #4CAF50; }
-.difficulty-badge.moderate { background: #FF9800; }
+.difficulty-badge.easy { background: #4caf50; }
+.difficulty-badge.moderate { background: #ff9800; }
 .difficulty-badge.hard { background: #f44336; }
+.difficulty-badge.expert { background: #7f1d1d; }
 
 .trail-info {
   padding: 16px;
 }
-.download-link {
-  color: #333;
-  text-decoration: none;
-  cursor: pointer;
+
+.trail-info h3 {
+  margin: 0 0 8px;
+  color: #0f3d2d;
 }
 
-.download-link:hover {
-  color: #666;
-}
-
-.trail-stats {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
-}
 .trail-info p {
-  color: #444;
+  display: -webkit-box;
+  min-height: 3em;
+  margin: 0 0 12px;
+  overflow: hidden;
+  color: #52616f;
   line-height: 1.5;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
 }
 
-.loading-container {
-  display: flex;
-  justify-content: center;
+.trail-tags {
+  margin-top: 12px;
+}
+
+.trail-tags span {
+  padding: 5px 9px;
+  border-radius: 999px;
+  color: #365247;
+  background: #edf7f1;
+  font-size: 0.76rem;
+  font-weight: 700;
+}
+
+.trail-card-link,
+.show-trail-btn,
+.trails-empty button {
+  display: inline-flex;
   align-items: center;
-  min-height: 300px;
+  gap: 6px;
+  border: 0;
+  border-radius: 999px;
+  padding: 9px 13px;
+  color: #ffffff;
+  background: #0f5c4d;
+  font-weight: 800;
+  cursor: pointer;
+  text-decoration: none;
 }
 
 .show-trail-btn {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin-top: 10px;
-  padding: 8px 12px;
-  background: #007AFF;
-  color: white;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
+  color: #0f5c4d;
+  background: #e5f4ef;
 }
 
-.show-trail-btn:hover {
-  background: #0056b3;
+.trails-empty {
+  grid-column: 1 / -1;
+  padding: 30px;
+  border: 1px dashed #a9d8b7;
+  border-radius: 18px;
+  color: #52616f;
+  text-align: center;
+  background: #f8fcfa;
 }
 
-.trail-actions {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 8px;
-  margin-top: 8px;
+.trails-empty .material-icons {
+  display: block;
+  color: #1f7a55;
+  font-size: 38px;
 }
 
-.icon-button {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 4px;
-  padding: 8px;
-  border: none;
-  border-radius: 6px;
-  background: none;
-  cursor: pointer;
-  color: #007AFF;
-  text-decoration: none;
+@media (max-width: 980px) {
+  .trails-container {
+    padding: 18px;
+  }
+
+  .trails-toolbar,
+  .trails-content-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .trails-map {
+    height: 420px;
+  }
 }
 
-.icon-button:hover {
-  color: #0056b3;
-  background: rgba(0, 122, 255, 0.08);
-}
-.icon-button.active {
-  color: #ff4400;
-}
+@media (max-width: 640px) {
+  .trails-toolbar {
+    border-radius: 16px;
+  }
 
-.trail-detail-link {
-  background: rgba(0, 122, 255, 0.1);
-  font-weight: 600;
+  .trails-map-card,
+  .latest-trails-card,
+  .trail-results-section {
+    padding: 14px;
+    border-radius: 18px;
+  }
 }

--- a/src/pages/Trails.tsx
+++ b/src/pages/Trails.tsx
@@ -1,12 +1,11 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Link } from 'react-router-dom';
 
-import { Spinner } from '../components/Spinner';
 import './Trails.css';
 import { Trail } from '../types/Trail'
 
 import { useAlltracks } from '../components/Store';
-import { parseTrailFile, parseTrails } from '../utils/trailUtils';
+import { parseTrailFile, parseTrails, difficultyMap, routeTypeMap } from '../utils/trailUtils';
 
 import { Map as LeafletMap } from 'leaflet';
 import { MapContainer, TileLayer, Marker, Popup, useMap, Polyline } from 'react-leaflet';
@@ -16,18 +15,25 @@ import { Icon } from 'leaflet';
 import markerIcon from 'leaflet/dist/images/marker-icon.png';
 import markerShadow from 'leaflet/dist/images/marker-shadow.png';
 
+type DifficultyFilter = '' | 'easy' | 'moderate' | 'hard' | 'expert';
+type RouteFilter = '' | 'loop' | 'out-and-back' | 'point-to-point';
+type SortOption = 'latest' | 'distance' | 'rating';
+
+const PAGE_SIZE = 100n;
+const DEFAULT_TRAIL_IMAGE = '/alltracks_hero.png';
+
 export const Trails = () => {
   const alltracks = useAlltracks();
   const [trails, setTrails] = useState<Trail[]>([]);
-
-  const DEFAULT_TRAIL_IMAGE = '/alltracks_hero.png';
-  const [selectedDifficulty, setSelectedDifficulty] = useState('');
+  const [searchTerm, setSearchTerm] = useState('');
+  const [selectedDifficulty, setSelectedDifficulty] = useState<DifficultyFilter>('');
+  const [selectedRouteType, setSelectedRouteType] = useState<RouteFilter>('');
+  const [sortBy, setSortBy] = useState<SortOption>('latest');
   const [isLoading, setIsLoading] = useState(true);
-  const [mapBounds, setMapBounds] = useState(null);
+  const [errorMessage, setErrorMessage] = useState('');
   const mapRef = useRef<LeafletMap>(null);
   const [selectedTrailId, setSelectedTrailId] = useState<number | null>(null);
   const [trailPath, setTrailPath] = useState<LatLngTuple[]>([]);
-
 
   const [defaultCenter, setDefaultCenter] = useState<LatLngTuple>([49.2827, -123.1207]);
   const customIcon = new Icon({
@@ -38,53 +44,103 @@ export const Trails = () => {
   });
 
   useEffect(() => {
-    if ("geolocation" in navigator) {
+    if ('geolocation' in navigator) {
       navigator.geolocation.getCurrentPosition((position) => {
         const { latitude, longitude } = position.coords;
         setDefaultCenter([latitude, longitude] as LatLngTuple);
       });
     }
   }, []);
-  // Filter trails based on selected difficulty
-  const filteredTrails = selectedDifficulty
-    ? trails.filter(trail => trail.difficulty === selectedDifficulty)
-    : trails;
 
-  // useEffect(() => {
-  //   fetchTrails();
-  // }, [selectedDifficulty]);
+  const sortTrails = useCallback((items: Trail[]) => {
+    return [...items].sort((a, b) => {
+      if (sortBy === 'distance') {
+        return a.distance - b.distance;
+      }
 
-  const fetchTrails = async () => {
+      if (sortBy === 'rating') {
+        return b.rating - a.rating;
+      }
+
+      const aCreated = a.createdAt || Number(a.id);
+      const bCreated = b.createdAt || Number(b.id);
+      return bCreated - aCreated;
+    });
+  }, [sortBy]);
+
+  const visibleTrails = useMemo(() => {
+    const normalizedSearch = searchTerm.trim().toLowerCase();
+    const filtered = trails.filter((trail) => {
+      const matchesSearch = !normalizedSearch ||
+        trail.name.toLowerCase().includes(normalizedSearch) ||
+        trail.description.toLowerCase().includes(normalizedSearch) ||
+        trail.tags.some((tag) => tag.toLowerCase().includes(normalizedSearch));
+      const matchesDifficulty = !selectedDifficulty || trail.difficulty === selectedDifficulty;
+      const matchesRoute = !selectedRouteType || trail.routeType === selectedRouteType;
+
+      return matchesSearch && matchesDifficulty && matchesRoute;
+    });
+
+    return sortTrails(filtered);
+  }, [searchTerm, selectedDifficulty, selectedRouteType, sortTrails, trails]);
+
+  const latestTrails = useMemo(() => sortTrails(trails).slice(0, 6), [sortTrails, trails]);
+
+  const fetchTrails = useCallback(async () => {
     setIsLoading(true);
+    setErrorMessage('');
 
-    const result = await alltracks.getTrails({ "ttype": { "tloop": null } }, 0n, 100n);
-    const formattedTrails = parseTrails(result);
-    setTrails(formattedTrails);
-    setIsLoading(false);
-  };
+    try {
+      const trimmedSearch = searchTerm.trim();
+      const result = trimmedSearch
+        ? await alltracks.searchTrails(trimmedSearch, 0n, PAGE_SIZE)
+        : selectedDifficulty
+          ? await alltracks.getTrails({ difficulty: difficultyMap[selectedDifficulty] }, 0n, PAGE_SIZE)
+          : selectedRouteType
+            ? await alltracks.getTrails({ ttype: routeTypeMap[selectedRouteType] }, 0n, PAGE_SIZE)
+            : await alltracks.searchTrails('', 0n, PAGE_SIZE);
+
+      setTrails(parseTrails(result));
+    } catch (error) {
+      console.error('Error loading trails:', error);
+      setErrorMessage('Unable to load trails right now. Try refreshing the page.');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [alltracks, searchTerm, selectedDifficulty, selectedRouteType]);
+
+  useEffect(() => {
+    const timeoutId = window.setTimeout(fetchTrails, 250);
+    return () => window.clearTimeout(timeoutId);
+  }, [fetchTrails]);
 
   const fetchTrailsInView = async (bounds) => {
     setIsLoading(true);
-    const result = await alltracks.getTrailsInBounds({
-      north: bounds._northEast.lat,
-      south: bounds._southWest.lat,
-      east: bounds._northEast.lng,
-      west: bounds._southWest.lng
-    });
+    setErrorMessage('');
 
-    const formattedTrails = parseTrails(result);
-    console.log(formattedTrails)
-    setTrails(formattedTrails);
-    setIsLoading(false);
+    try {
+      const result = await alltracks.getTrailsInBounds({
+        north: bounds._northEast.lat,
+        south: bounds._southWest.lat,
+        east: bounds._northEast.lng,
+        west: bounds._southWest.lng
+      });
+
+      setTrails(parseTrails(result));
+    } catch (error) {
+      console.error('Error loading trails in view:', error);
+      setErrorMessage('Unable to load trails in this map area.');
+    } finally {
+      setIsLoading(false);
+    }
   };
 
   const handleMapMove = () => {
-    if (mapRef.current) {
-      const bounds = mapRef.current.getBounds();
-      setMapBounds(bounds);
-      fetchTrailsInView(bounds);
+    if (mapRef.current && !searchTerm.trim()) {
+      fetchTrailsInView(mapRef.current.getBounds());
     }
   };
+
   const MapEvents = () => {
     const map = useMap();
 
@@ -99,6 +155,7 @@ export const Trails = () => {
 
     return null;
   };
+
   const handleTrailToggle = async (trail: Trail) => {
     if (selectedTrailId === Number(trail.id)) {
       setSelectedTrailId(null);
@@ -110,92 +167,166 @@ export const Trails = () => {
     }
   };
 
+  const resetFilters = () => {
+    setSearchTerm('');
+    setSelectedDifficulty('');
+    setSelectedRouteType('');
+    setSortBy('latest');
+  };
+
   return (
     <div className="trails-container">
-
       <header className="trails-header">
-        <h1>Hiking Trails</h1>
-        <div className="trails-filters">
-          <select
-            value={selectedDifficulty}
-            onChange={(e) => setSelectedDifficulty(e.target.value)}
-          >
-            <option value="">All Difficulties</option>
-            <option value="easy">Easy</option>
-            <option value="moderate">Moderate</option>
-            <option value="hard">Hard</option>
-            <option value="expert">Expert</option>
-          </select>
+        <div>
+          <p className="trails-eyebrow">Trail finder</p>
+          <h1>Hiking Trails</h1>
+          <p>Search the trail catalog, narrow by difficulty or route type, and discover the newest routes added by the community.</p>
         </div>
       </header>
 
-      <MapContainer
-        center={defaultCenter}
-        zoom={13}
-        className="trails-map"
-        ref={mapRef}
-      >
-        <TileLayer
-          url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-          attribution='&copy; OpenStreetMap contributors'
-        />
-        <MapEvents />
-        {filteredTrails.map(trail => (
-          trail.startPoint && (
-            <Marker
-              key={trail.id}
-              position={[trail.startPoint.latitude, trail.startPoint.longitude]}
-              icon={customIcon}>
-
-              <Popup>
-                <div className="trail-popup">
-                  <h3>{trail.name}</h3>
-                  <div className="trail-stats">
-                    <span>{trail.distance} km</span>
-                    <span>{trail.duration} hours</span>
-                    <span>{trail.elevationGain} m</span>
-                  </div>
-                  <div className="trail-actions">
-                    <Link
-                      to={`/trail/${trail.id}`}
-                      className="icon-button trail-detail-link"
-                      title="Open trail details"
-                      aria-label={`Open details for ${trail.name}`}
-                    >
-                      <span className="material-icons">open_in_new</span>
-                    </Link>
-                    <button
-                      className={`icon-button ${selectedTrailId === Number(trail.id) ? 'active' : ''}`}
-                      onClick={() => handleTrailToggle(trail)}
-                      title="Show route on map"
-                      aria-label={`Show route for ${trail.name}`}
-                    >
-                      <span className="material-icons">route</span>
-                    </button>
-                    <a
-                      href={trail.trailfile.url}
-                      download
-                      className="icon-button"
-                      title="Download trail file"
-                      aria-label={`Download ${trail.name} trail file`}
-                    >
-                      <span className="material-icons">download</span>
-                    </a>
-                  </div>
-                </div>
-              </Popup>
-            </Marker>
-          )
-        ))}
-        {selectedTrailId && trailPath && (
-          <Polyline
-            positions={trailPath}
-            color="#ff4400"
-            weight={3}
+      <section className="trails-toolbar" aria-label="Trail search and filters">
+        <label className="trail-search-field">
+          <span className="material-icons">search</span>
+          <input
+            type="search"
+            placeholder="Search by name, description, or tag"
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
           />
-        )}
-      </MapContainer>
+        </label>
+        <select value={selectedDifficulty} onChange={(e) => setSelectedDifficulty(e.target.value as DifficultyFilter)}>
+          <option value="">All difficulties</option>
+          <option value="easy">Easy</option>
+          <option value="moderate">Moderate</option>
+          <option value="hard">Hard</option>
+          <option value="expert">Expert</option>
+        </select>
+        <select value={selectedRouteType} onChange={(e) => setSelectedRouteType(e.target.value as RouteFilter)}>
+          <option value="">All route types</option>
+          <option value="loop">Loop</option>
+          <option value="out-and-back">Out and back</option>
+          <option value="point-to-point">Point to point</option>
+        </select>
+        <select value={sortBy} onChange={(e) => setSortBy(e.target.value as SortOption)}>
+          <option value="latest">Latest added</option>
+          <option value="rating">Highest rated</option>
+          <option value="distance">Shortest distance</option>
+        </select>
+        <button type="button" onClick={resetFilters}>Reset</button>
+      </section>
 
+      {errorMessage && <div className="trails-alert">{errorMessage}</div>}
+
+      <section className="trails-content-grid">
+        <div className="trails-map-card">
+          <div className="trails-section-heading">
+            <div>
+              <h2>Explore on the map</h2>
+              <span>{visibleTrails.length} trail{visibleTrails.length === 1 ? '' : 's'} matching your filters</span>
+            </div>
+            {isLoading && <span className="trails-loading"><span className="material-icons spinning">refresh</span> Loading</span>}
+          </div>
+          <MapContainer center={defaultCenter} zoom={13} className="trails-map" ref={mapRef}>
+            <TileLayer
+              url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
+              attribution='&copy; OpenStreetMap contributors'
+            />
+            <MapEvents />
+            {visibleTrails.map(trail => (
+              trail.startPoint && (
+                <Marker key={trail.id} position={[trail.startPoint.latitude, trail.startPoint.longitude]} icon={customIcon}>
+                  <Popup>
+                    <div className="trail-popup">
+                      <h3>{trail.name}</h3>
+                      <div className="trail-stats">
+                        <span>{trail.distance} km</span>
+                        <span>{trail.duration} hours</span>
+                        <span>{trail.elevationGain} m</span>
+                      </div>
+                      <div className="trail-actions">
+                        <Link to={`/trail/${trail.id}`} className="icon-button trail-detail-link" title="Open trail details" aria-label={`Open details for ${trail.name}`}>
+                          <span className="material-icons">open_in_new</span>
+                        </Link>
+                        <button className={`icon-button ${selectedTrailId === Number(trail.id) ? 'active' : ''}`} onClick={() => handleTrailToggle(trail)} title="Show route on map" aria-label={`Show route for ${trail.name}`}>
+                          <span className="material-icons">route</span>
+                        </button>
+                        <a href={trail.trailfile.url} download className="icon-button" title="Download trail file" aria-label={`Download ${trail.name} trail file`}>
+                          <span className="material-icons">download</span>
+                        </a>
+                      </div>
+                    </div>
+                  </Popup>
+                </Marker>
+              )
+            ))}
+            {selectedTrailId && trailPath && <Polyline positions={trailPath} color="#ff4400" weight={3} />}
+          </MapContainer>
+        </div>
+
+        <aside className="latest-trails-card">
+          <div className="trails-section-heading">
+            <div>
+              <h2>Latest added trails</h2>
+              <span>Fresh routes from the community</span>
+            </div>
+          </div>
+          <div className="latest-trails-list">
+            {latestTrails.length > 0 ? latestTrails.map((trail) => (
+              <Link to={`/trail/${trail.id}`} className="latest-trail-item" key={trail.id}>
+                <img src={trail.photos[0] || DEFAULT_TRAIL_IMAGE} alt="" />
+                <div>
+                  <strong>{trail.name}</strong>
+                  <span>{trail.distance} km · {trail.difficulty} · {trail.rating}/5</span>
+                </div>
+              </Link>
+            )) : <p className="trails-empty">No trails have been added yet.</p>}
+          </div>
+        </aside>
+      </section>
+
+      <section className="trail-results-section">
+        <div className="trails-section-heading">
+          <div>
+            <h2>Trail list</h2>
+            <span>Sorted by {sortBy === 'latest' ? 'latest added' : sortBy === 'rating' ? 'highest rated' : 'shortest distance'}</span>
+          </div>
+        </div>
+        <div className="trails-grid">
+          {visibleTrails.length > 0 ? visibleTrails.map((trail) => (
+            <article className="trail-card" key={trail.id}>
+              <div className="trail-image">
+                <img src={trail.photos[0] || DEFAULT_TRAIL_IMAGE} alt={trail.name} />
+                <span className={`difficulty-badge ${trail.difficulty}`}>{trail.difficulty}</span>
+              </div>
+              <div className="trail-info">
+                <h3>{trail.name}</h3>
+                <p>{trail.description}</p>
+                <div className="trail-stats">
+                  <span>{trail.distance} km</span>
+                  <span>{trail.duration} hrs</span>
+                  <span>{trail.elevationGain} m gain</span>
+                </div>
+                <div className="trail-tags">
+                  {trail.tags.slice(0, 4).map((tag) => <span key={tag}>{tag}</span>)}
+                </div>
+                <div className="trail-actions">
+                  <Link to={`/trail/${trail.id}`} className="trail-card-link">View details</Link>
+                  <button className="show-trail-btn" onClick={() => handleTrailToggle(trail)}>
+                    <span className="material-icons">route</span>
+                    {selectedTrailId === Number(trail.id) ? 'Hide route' : 'Show route'}
+                  </button>
+                </div>
+              </div>
+            </article>
+          )) : (
+            <div className="trails-empty">
+              <span className="material-icons">hiking</span>
+              <p>No trails match your filters.</p>
+              <button type="button" onClick={resetFilters}>Clear filters</button>
+            </div>
+          )}
+        </div>
+      </section>
     </div>
   );
 };

--- a/src/types/Trail.ts
+++ b/src/types/Trail.ts
@@ -1,7 +1,6 @@
-export 
-
-interface Trail {
+export interface Trail {
   id: bigint;
+  createdAt?: number;
   name: string;
   distance: number;
   elevationGain: number;

--- a/src/utils/trailUtils.ts
+++ b/src/utils/trailUtils.ts
@@ -43,6 +43,7 @@ export const parseTrails = (trails: TrailType[]): Trail[] => {
 
     return {
       id,
+      createdAt: Number(trail.createdAt) / 1_000_000,
       name,
       description,
       distance: Number(distance.toFixed(2)),


### PR DESCRIPTION
### Motivation
- Provide a richer trails discovery experience so users can search and filter trails and quickly find the latest community routes.
- Surface newest trails added and make it easy to explore routes on a map or in a list with sorting and reset controls.

### Description
- Reworked the Trails UI into a discovery page with debounced search, difficulty and route-type filters, sort controls (latest/rating/distance), reset behavior, and improved empty/error states (`src/pages/Trails.tsx`).
- Added a two-column layout with an interactive map (markers, popups, route toggle) and a “Latest added trails” sidebar that lists newest trails using creation timestamps (`src/pages/Trails.tsx`, `src/pages/Trails.css`).
- Persisted `createdAt` in the local `Trail` type and mapped backend nanosecond `createdAt` to milliseconds in `parseTrails` for correct latest-first sorting (`src/types/Trail.ts`, `src/utils/trailUtils.ts`).
- Refreshed page styling for the new toolbar, latest panel, trail cards and responsiveness (`src/pages/Trails.css`).

### Testing
- `yarn build` completed successfully (Vite production build ran without errors). 
- `yarn lint` reported pre-existing repository-wide lint issues unrelated to these changes (full repo lint failed), while targeted linting of the modified UI files did not introduce new TypeScript errors. 
- `git diff --check` against the modified files passed with no whitespace errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a51079c662c833095812db208986f9e)